### PR TITLE
feat(PlayerView): prevent sleep only while video is actually playing

### DIFF
--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -539,9 +539,16 @@ struct PlayerView: View {
                 }
             }
         }
-        .onChange(of: isPlaying) { _ in
+        .onChange(of: isPlaying) { newValue in
             if !isPlaying {
                 savePlaybackPosition()
+                #if os(macOS)
+                enableScreenSaver()
+                #endif
+            } else {
+                #if os(macOS)
+                disableScreenSaver()
+                #endif
             }
         }
         .task(id: isPlayerReady) {


### PR DESCRIPTION
## Summary

Fixes #51 — macOS sleep prevention now correctly tracks `isPlaying` state instead of only the view lifecycle.

## Changes

In `NexusPVR/Features/Player/PlayerView.swift`, the existing `.onChange(of: isPlaying)` handler now also manages the IOPM sleep assertion:

- **When `isPlaying` becomes `false`** → calls `enableScreenSaver()` to release the sleep assertion
- **When `isPlaying` becomes `true`** → calls `disableScreenSaver()` to re-acquire the assertion

Previously, `disableScreenSaver()` was only called in `.onAppear` and `enableScreenSaver()` only in `.onDisappear`. This meant pausing the video (without dismissing the player) left the sleep assertion active indefinitely.

## Root Cause

The sleep assertion was tied to view lifecycle (`.onAppear/.onDisappear`) rather than actual playback state. On macOS, locking the screen or closing the lid does not trigger `.onDisappear`, so the IOPMAssertion was never released after pausing.

## Testing

1. Start playing a video on macOS
2. Pause the video
3. Lock the screen — laptop should sleep normally
4. Unlock and resume playback — sleep prevention should reactivate
