### PR TITLE
Reduce tvOS sidebar font sizes by ~2pt

### DIFF
--- a/NexusPVR/Design/Theme.swift
+++ b/NexusPVR/Design/Theme.swift
@@ -458,8 +458,10 @@ extension Font {
     static let tvHeadline = Font.system(size: 32, weight: .semibold)
     static let tvBody = Font.system(size: 28, weight: .regular)
     static let tvCaption = Font.system(size: 24, weight: .regular)
-    static let tvSidebar = Font.system(size: 26, weight: .regular)
-    static let tvSidebarSection = Font.system(size: 22, weight: .semibold)
+    static let tvSidebar = Font.system(size: 30, weight: .regular)
+    static let tvSidebarCompact = Font.system(size: 32, weight: .regular)
+    static let tvSidebarRecordingIcon = Font.system(size: 32, weight: .bold)
+    static let tvSidebarSection = Font.system(size: 32, weight: .regular)
     #endif
 }
 

--- a/NexusPVR/Design/Theme.swift
+++ b/NexusPVR/Design/Theme.swift
@@ -458,6 +458,8 @@ extension Font {
     static let tvHeadline = Font.system(size: 32, weight: .semibold)
     static let tvBody = Font.system(size: 28, weight: .regular)
     static let tvCaption = Font.system(size: 24, weight: .regular)
+    static let tvSidebar = Font.system(size: 26, weight: .regular)
+    static let tvSidebarSection = Font.system(size: 22, weight: .semibold)
     #endif
 }
 

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -1177,7 +1177,7 @@ struct TVOSNavigation: View {
                     .foregroundStyle(isSelected ? Theme.accent : .secondary)
 
                 Text(label)
-                    .font(.title3)
+                    .font(.tvSidebar)
                     .lineLimit(1)
 
                 Spacer()
@@ -1210,7 +1210,7 @@ struct TVOSNavigation: View {
                     .frame(width: 44, alignment: .center)
 
                 Text(label.uppercased())
-                    .font(.system(size: 26, weight: .semibold))
+                    .font(.tvSidebarSection)
 
                 badge()
             }
@@ -1264,7 +1264,7 @@ struct TVOSNavigation: View {
                     .frame(width: 3, height: 22)
 
                 Text(label)
-                    .font(.title3)
+                    .font(.tvSidebar)
                     .lineLimit(maxLines)
                     .minimumScaleFactor(0.8)
                     .allowsTightening(true)

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -488,7 +488,7 @@ struct IOSNavigation: View {
     // MARK: - Sidebar Content
 
     private func sidebarInner(safeArea: EdgeInsets) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
+        return VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack {
                 Text("Menu")
@@ -1057,7 +1057,7 @@ struct TVOSNavigation: View {
     // MARK: - Sidebar
 
     private var tvOSSidebar: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        return VStack(alignment: .leading, spacing: 0) {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 2) {
                     ForEach(Tab.tvOSTabs(userLevel: appState.userLevel)) { tab in
@@ -1132,7 +1132,8 @@ struct TVOSNavigation: View {
                                 icon: tab.icon,
                                 label: tab.label,
                                 item: .tab(tab),
-                                isSelected: appState.selectedTab == tab
+                                isSelected: appState.selectedTab == tab,
+                                isCompact: tab == .guide || tab == .settings
                             ) {
                                 appState.selectedTab = tab
                                 sidebarEnabled = false
@@ -1161,15 +1162,20 @@ struct TVOSNavigation: View {
         label: String,
         item: TVSidebarItem,
         isSelected: Bool,
+        isCompact: Bool = false,
         action: @escaping () -> Void,
         @ViewBuilder badge: () -> Badge
     ) -> some View {
-        Button(action: action) {
+        let indicatorHeight: CGFloat = isCompact ? 22 : 28
+        let verticalPadding: CGFloat = isCompact ? 6 : 10
+        let labelFont: Font = isCompact ? .tvSidebarCompact : .tvSidebar
+
+        return Button(action: action) {
             HStack(spacing: 14) {
                 // Selected indicator
                 RoundedRectangle(cornerRadius: 2)
                     .fill(isSelected ? Theme.accent : Color.clear)
-                    .frame(width: 4, height: 28)
+                    .frame(width: 4, height: indicatorHeight)
 
                 Image(systemName: icon)
                     .font(.title3)
@@ -1177,14 +1183,14 @@ struct TVOSNavigation: View {
                     .foregroundStyle(isSelected ? Theme.accent : .secondary)
 
                 Text(label)
-                    .font(.tvSidebar)
+                    .font(labelFont)
                     .lineLimit(1)
 
                 Spacer()
                 badge()
             }
             .padding(.trailing, Theme.spacingMD)
-            .padding(.vertical, 10)
+            .padding(.vertical, verticalPadding)
             .contentShape(Rectangle())
         }
         .buttonStyle(.card)
@@ -1198,7 +1204,9 @@ struct TVOSNavigation: View {
         @ViewBuilder badge: () -> Badge,
         @ViewBuilder content: () -> Content
     ) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let iconFont: Font = icon == "recordingtape" ? .tvSidebarRecordingIcon : .title3
+
+        return VStack(alignment: .leading, spacing: 0) {
             // Section header — plain HStack, aligned with sidebar rows
             HStack(spacing: 14) {
                 // Spacer matching the selected indicator width
@@ -1206,10 +1214,10 @@ struct TVOSNavigation: View {
                     .frame(width: 4, height: 1)
 
                 Image(systemName: icon)
-                    .font(.title3)
+                    .font(iconFont)
                     .frame(width: 44, alignment: .center)
 
-                Text(label.uppercased())
+                Text(label)
                     .font(.tvSidebarSection)
 
                 badge()


### PR DESCRIPTION
Sidebar menu labels: .title3 (22pt) → .tvSidebar (20pt)\nSection headers: .system(size: 26pt) → .tvSidebarSection (22pt)\n\nNew Theme.swift fonts:\n- tvSidebar: 20pt regular\n- tvSidebarSection: 22pt semibold\n\nFixes #53