### PR TITLE
Add channel groups as sub-menus to Guide sidebar (Dispatcharr only)

### DIFF
--- a/NexusPVR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NexusPVR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Drvolks/MPVKit",
       "state" : {
-        "revision" : "a625a03c8c74e9b55857cf50f49e7ef652b6e4bb",
+        "revision" : "1de0ac9c1603036702213321773c7c94d0fd8ac7",
         "version" : "0.41.0-drvolks.6"
       }
     }

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -19,6 +19,8 @@ nonisolated struct UserPreferences: Codable {
     var subtitleSize: SubtitleSize = .medium
     var subtitleBackground: Bool = true
     var preferredSubtitleLanguage: String? = nil
+    var guideShowGroupsInSidebar: Bool = false
+    var guideGroupIds: [Int] = []
     var updatedAt: Date = .distantPast
 
     /// The GPU API for the current platform.
@@ -46,6 +48,8 @@ nonisolated struct UserPreferences: Codable {
         case subtitleSize
         case subtitleBackground
         case preferredSubtitleLanguage
+        case guideShowGroupsInSidebar
+        case guideGroupIds
         case updatedAt
     }
 
@@ -71,6 +75,8 @@ nonisolated struct UserPreferences: Codable {
         subtitleSize = try container.decodeIfPresent(SubtitleSize.self, forKey: .subtitleSize) ?? .medium
         subtitleBackground = try container.decodeIfPresent(Bool.self, forKey: .subtitleBackground) ?? true
         preferredSubtitleLanguage = try container.decodeIfPresent(String.self, forKey: .preferredSubtitleLanguage)
+        guideShowGroupsInSidebar = try container.decodeIfPresent(Bool.self, forKey: .guideShowGroupsInSidebar) ?? false
+        guideGroupIds = try container.decodeIfPresent([Int].self, forKey: .guideGroupIds) ?? []
         updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? .distantPast
     }
 
@@ -87,6 +93,8 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(subtitleSize, forKey: .subtitleSize)
         try container.encode(subtitleBackground, forKey: .subtitleBackground)
         try container.encodeIfPresent(preferredSubtitleLanguage, forKey: .preferredSubtitleLanguage)
+        try container.encode(guideShowGroupsInSidebar, forKey: .guideShowGroupsInSidebar)
+        try container.encode(guideGroupIds, forKey: .guideGroupIds)
         try container.encode(updatedAt, forKey: .updatedAt)
     }
 

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -101,14 +101,12 @@ struct GuideView: View {
                 keywords = UserPreferences.load().keywords
                 await viewModel.loadData(using: client, epgCache: epgCache)
                 viewModel.updateKeywordMatches(keywords: keywords)
-                #if !os(tvOS)
                 if !appState.guideChannelFilter.isEmpty {
                     viewModel.channelSearchText = appState.guideChannelFilter
                 }
                 if let groupId = appState.guideGroupFilter {
                     viewModel.selectedGroupId = groupId
                 }
-                #endif
             }
             .onChange(of: viewModel.channelSearchText) {
                 Task { viewModel.updateKeywordMatches(keywords: keywords) }
@@ -116,14 +114,12 @@ struct GuideView: View {
             .onChange(of: epgCache.isFullyLoaded) {
                 Task { viewModel.updateKeywordMatches(keywords: keywords) }
             }
-            #if !os(tvOS)
             .onChange(of: appState.guideChannelFilter) {
                 Task { viewModel.channelSearchText = appState.guideChannelFilter }
             }
             .onChange(of: appState.guideGroupFilter) {
                 Task { viewModel.selectedGroupId = appState.guideGroupFilter }
             }
-            #endif
             .onChange(of: scenePhase) {
                 if scenePhase == .active {
                     Task { await refreshRecordings() }

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -13,6 +13,9 @@ struct SettingsView: View {
     #if os(tvOS)
     @Environment(\.requestSidebarFocus) private var requestSidebarFocus
     #endif
+    #if os(iOS) || os(tvOS)
+    @EnvironmentObject private var epgCache: EPGCache
+    #endif
     @State private var showingUnlinkConfirm = false
     @State private var seekBackwardSeconds: Int = UserPreferences.load().seekBackwardSeconds
     @State private var seekForwardSeconds: Int = UserPreferences.load().seekForwardSeconds
@@ -23,6 +26,10 @@ struct SettingsView: View {
     @State private var subtitleMode: SubtitleMode = UserPreferences.load().subtitleMode
     @State private var subtitleSize: SubtitleSize = UserPreferences.load().subtitleSize
     @State private var subtitleBackground: Bool = UserPreferences.load().subtitleBackground
+    #if DISPATCHERPVR
+    @State private var guideShowGroupsInSidebar: Bool = UserPreferences.load().guideShowGroupsInSidebar
+    @State private var guideGroupIds: [Int] = UserPreferences.load().guideGroupIds
+    #endif
     @ObservedObject private var eventLog: NetworkEventLog
 
     init(eventLog: NetworkEventLog = Dependencies.networkEventLog) {
@@ -60,6 +67,9 @@ struct SettingsView: View {
             List {
                 serverSection
                 playbackSection
+                #if DISPATCHERPVR
+                guideSection
+                #endif
                 #if DEBUG
                 debugStreamSection
                 #endif
@@ -794,6 +804,58 @@ struct SettingsView: View {
             return "Legacy OpenGL-based rendering. Broad compatibility but no Picture-in-Picture support."
         }
     }
+
+    #if DISPATCHERPVR
+    private var guideSection: some View {
+        Section {
+            Toggle("Show Groups in Sidebar", isOn: $guideShowGroupsInSidebar)
+                .onChange(of: guideShowGroupsInSidebar) { newValue in
+                    var prefs = UserPreferences.load()
+                    prefs.guideShowGroupsInSidebar = newValue
+                    prefs.save()
+                }
+            if guideShowGroupsInSidebar {
+                if epgCache.channelGroups.isEmpty {
+                    Text("No channel groups available")
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    let populatedGroups = epgCache.channelGroups.filter { group in
+                        epgCache.visibleChannels.contains { $0.groupId == group.id }
+                    }
+                    if populatedGroups.isEmpty {
+                        Text("No channels in any group")
+                            .foregroundStyle(Theme.textSecondary)
+                    } else {
+                        ForEach(populatedGroups) { group in
+                            let isSelected = guideGroupIds.contains(group.id)
+                            Button {
+                                if isSelected {
+                                    guideGroupIds.removeAll { $0 == group.id }
+                                } else {
+                                    guideGroupIds.append(group.id)
+                                }
+                                var prefs = UserPreferences.load()
+                                prefs.guideGroupIds = guideGroupIds
+                                prefs.save()
+                            } label: {
+                                HStack {
+                                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                                        .foregroundStyle(isSelected ? Theme.accent : Theme.textTertiary)
+                                    Text(group.name)
+                                        .foregroundStyle(Theme.textPrimary)
+                                    Spacer()
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        } header: {
+            Text("Guide")
+        }
+    }
+    #endif
 
     #if DEBUG
     private var debugStreamSection: some View {

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -204,6 +204,12 @@ struct SettingsView: View {
                     }
                     .focusSection()
 
+                #if DISPATCHERPVR
+                    tvOSGuideSettingsSection
+                        .focusSection()
+
+                #endif
+
                 #if DEBUG
                     TVSettingsSection(
                         title: "Debug",
@@ -403,6 +409,107 @@ struct SettingsView: View {
         }
         .buttonStyle(TVSettingsRowButtonStyle())
     }
+
+    #if DISPATCHERPVR
+    private var tvOSGuideSettingsSection: some View {
+        TVSettingsSection(
+            title: "Guide",
+            icon: "rectangle.grid.1x2"
+        ) {
+            VStack(spacing: Theme.spacingMD) {
+                Toggle("Show Groups in Sidebar", isOn: $guideShowGroupsInSidebar)
+                    .font(.system(size: 24, weight: .semibold))
+                    .padding(.horizontal, Theme.spacingMD)
+                    .padding(.vertical, Theme.spacingSM)
+                    .background(Theme.guideNowPlaying.opacity(0.78))
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSM))
+                    .onChange(of: guideShowGroupsInSidebar) { newValue in
+                        var prefs = UserPreferences.load()
+                        prefs.guideShowGroupsInSidebar = newValue
+                        prefs.save()
+                        if !newValue {
+                            appState.guideGroupFilter = nil
+                            appState.guideChannelFilter = ""
+                        }
+                        NotificationCenter.default.post(name: .preferencesDidSync, object: nil)
+                    }
+
+                if guideShowGroupsInSidebar {
+                    if epgCache.channelGroups.isEmpty {
+                        tvOSGuideStatusRow("No channel groups available")
+                    } else {
+                        let populatedGroups = epgCache.channelGroups.filter { group in
+                            epgCache.visibleChannels.contains { $0.groupId == group.id }
+                        }
+                        if populatedGroups.isEmpty {
+                            tvOSGuideStatusRow("No channels in any group")
+                        } else {
+                            Text("Included Groups")
+                                .font(.system(size: 18, weight: .medium))
+                                .foregroundStyle(Theme.textTertiary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, Theme.spacingMD)
+
+                            ForEach(populatedGroups) { group in
+                                tvOSGuideGroupToggleRow(group: group)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func tvOSGuideStatusRow(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 20, weight: .regular))
+            .foregroundStyle(Theme.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Theme.spacingMD)
+            .padding(.vertical, Theme.spacingMD)
+            .background(Theme.guideNowPlaying.opacity(0.78))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSM))
+    }
+
+    private func tvOSGuideGroupToggleRow(group: ChannelGroup) -> some View {
+        let isSelected = guideGroupIds.contains(group.id)
+
+        return Button {
+            if isSelected {
+                guideGroupIds.removeAll { $0 == group.id }
+            } else {
+                guideGroupIds.append(group.id)
+            }
+
+            var prefs = UserPreferences.load()
+            prefs.guideGroupIds = guideGroupIds
+            prefs.save()
+            if !guideGroupIds.isEmpty, appState.guideGroupFilter == group.id, !guideGroupIds.contains(group.id) {
+                appState.guideGroupFilter = nil
+                appState.guideChannelFilter = ""
+            }
+            NotificationCenter.default.post(name: .preferencesDidSync, object: nil)
+        } label: {
+            HStack(spacing: Theme.spacingMD) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(isSelected ? Theme.accent : Theme.textTertiary)
+
+                Text(group.name)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, Theme.spacingMD)
+            .padding(.vertical, Theme.spacingMD)
+            .background(Theme.guideNowPlaying.opacity(0.78))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSM))
+        }
+        .buttonStyle(TVSettingsRowButtonStyle())
+    }
+    #endif
 
     private var serverSummaryValue: String {
         let host = client.config.displayAddress.isEmpty ? "Not configured" : client.config.displayAddress

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -556,6 +556,29 @@ struct IOSNavigation: View {
                             ForEach(appState.topicKeywords, id: \.self) { keyword in
                                 sidebarTopicSubRow(keyword: keyword, count: appState.topicKeywordMatchCounts[keyword])
                             }
+                        } else if tab == .guide {
+                            // Guide header (non-tappable on iOS sidebar)
+                            sidebarRow(
+                                icon: tab.icon,
+                                label: tab.label,
+                                isSelected: appState.selectedTab == .guide,
+                                badge: { sidebarTabBadge(for: tab) }
+                            )
+                            .foregroundStyle(Theme.textSecondary)
+
+
+                            // Group sub-items (Dispatcharr only)
+                            #if DISPATCHERPVR
+                            let prefs = UserPreferences.load()
+                            if prefs.guideShowGroupsInSidebar {
+                                let populatedGroups = epgCache.channelGroups.filter { group in
+                                    epgCache.visibleChannels.contains { $0.groupId == group.id }
+                                }
+                                ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
+                                    sidebarGuideGroupSubRow(group: group)
+                                }
+                            }
+                            #endif
                         } else {
                             Button {
                                 appState.selectedTab = tab
@@ -741,6 +764,36 @@ struct IOSNavigation: View {
         .accessibilityIdentifier("topic-keyword-\(keyword)")
     }
 
+    #if DISPATCHERPVR
+    private func sidebarGuideGroupSubRow(group: ChannelGroup) -> some View {
+        let isSelected = appState.selectedTab == .guide && appState.guideGroupFilter == group.id
+        return Button {
+            appState.guideGroupFilter = group.id
+            appState.guideChannelFilter = ""
+            appState.selectedTab = .guide
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                isSidebarOpen = false
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Color.clear.frame(width: 28)
+                Text(group.name)
+                    .font(.subheadline)
+                Spacer()
+            }
+            .foregroundStyle(isSelected ? Theme.accent : Theme.textSecondary)
+            .padding(.horizontal, Theme.spacingLG)
+            .padding(.leading, Theme.spacingSM)
+            .padding(.vertical, 10)
+            .background(
+                isSelected ? Theme.accent.opacity(0.12) : Color.clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSM))
+        }
+        .accessibilityIdentifier("guide-group-\(group.id)")
+    }
+    #endif
+
     @ViewBuilder
     private func sidebarTabBadge(for tab: Tab) -> some View {
         if tab == .recordings && appState.recordingsHasActive {
@@ -914,6 +967,7 @@ struct IOSNavigation: View {
 struct TVOSNavigation: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var client: PVRClient
+    @EnvironmentObject private var epgCache: EPGCache
     @State private var sidebarEnabled = true
     @FocusState private var focusedItem: TVSidebarItem?
 
@@ -1127,6 +1181,29 @@ struct TVOSNavigation: View {
                                     isSelected: appState.selectedTab == .topics && appState.showingKeywordsEditor
                                 ) { EmptyView() }
                             }
+                        } else if tab == .guide {
+                            // Guide — non-tappable header, with group sub-items below
+                            tvOSSidebarSection(icon: tab.icon, label: tab.label) {
+                                EmptyView()
+                            } content: {
+                                #if DISPATCHERPVR
+                                let prefs = UserPreferences.load()
+                                if prefs.guideShowGroupsInSidebar {
+                                    let populatedGroups = epgCache.channelGroups.filter { group in
+                                        epgCache.visibleChannels.contains { $0.groupId == group.id }
+                                    }
+                                    ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
+                                        tvOSSidebarSubRow(
+                                            label: group.name,
+                                            item: .guideGroup(group.id),
+                                            isSelected: appState.selectedTab == .guide && appState.guideGroupFilter == group.id
+                                        ) {
+                                            EmptyView()
+                                        }
+                                    }
+                                }
+                                #endif
+                            }
                         } else {
                             tvOSSidebarRow(
                                 icon: tab.icon,
@@ -1307,6 +1384,10 @@ struct TVOSNavigation: View {
             return "topic-keyword-\(keyword)"
         case .topicManage:
             return "topic-manage"
+        #if DISPATCHERPVR
+        case .guideGroup(let groupId):
+            return "guide-group-\(groupId)"
+        #endif
         }
     }
 
@@ -1359,6 +1440,9 @@ enum TVSidebarItem: Hashable {
     case recordingsSeriesMore
     case topicKeyword(String)
     case topicManage
+    #if DISPATCHERPVR
+    case guideGroup(Int)
+    #endif
 }
 #endif
 

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -969,6 +969,9 @@ struct TVOSNavigation: View {
     @EnvironmentObject private var client: PVRClient
     @EnvironmentObject private var epgCache: EPGCache
     @State private var sidebarEnabled = true
+    #if DISPATCHERPVR
+    @State private var guideSidebarPreferences = UserPreferences.load()
+    #endif
     @FocusState private var focusedItem: TVSidebarItem?
 
     private let sidebarWidth: CGFloat = 440
@@ -1035,7 +1038,15 @@ struct TVOSNavigation: View {
         .onAppear {
             focusedItem = preferredSidebarFocusItem()
             appState.topicKeywords = UserPreferences.load().keywords
+            #if DISPATCHERPVR
+            guideSidebarPreferences = UserPreferences.load()
+            #endif
         }
+        #if DISPATCHERPVR
+        .onReceive(NotificationCenter.default.publisher(for: .preferencesDidSync)) { _ in
+            guideSidebarPreferences = UserPreferences.load()
+        }
+        #endif
         .onChange(of: focusedItem) { _, newItem in
             if newItem == nil {
                 // When sidebar loses focus, disable it so content can receive focus
@@ -1103,6 +1114,16 @@ struct TVOSNavigation: View {
                 return .topicKeyword(first)
             }
             return .topicManage
+        case .guide:
+            #if DISPATCHERPVR
+            if guideSidebarPreferences.guideShowGroupsInSidebar {
+                if let groupId = appState.guideGroupFilter {
+                    return .guideGroup(groupId)
+                }
+                return .guideAll
+            }
+            #endif
+            return .tab(.guide)
         default:
             return .tab(appState.selectedTab)
         }
@@ -1182,17 +1203,24 @@ struct TVOSNavigation: View {
                                 ) { EmptyView() }
                             }
                         } else if tab == .guide {
-                            // Guide — non-tappable header, with group sub-items below
-                            tvOSSidebarSection(icon: tab.icon, label: tab.label) {
-                                EmptyView()
-                            } content: {
-                                #if DISPATCHERPVR
-                                let prefs = UserPreferences.load()
-                                if prefs.guideShowGroupsInSidebar {
+                            #if DISPATCHERPVR
+                            if guideSidebarPreferences.guideShowGroupsInSidebar {
+                                // Guide section with an "All" row plus optional group shortcuts.
+                                tvOSSidebarSection(icon: tab.icon, label: tab.label) {
+                                    EmptyView()
+                                } content: {
+                                    tvOSSidebarSubRow(
+                                        label: "All Channels",
+                                        item: .guideAll,
+                                        isSelected: appState.selectedTab == .guide && appState.guideGroupFilter == nil
+                                    ) {
+                                        EmptyView()
+                                    }
+
                                     let populatedGroups = epgCache.channelGroups.filter { group in
                                         epgCache.visibleChannels.contains { $0.groupId == group.id }
                                     }
-                                    ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
+                                    ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                         tvOSSidebarSubRow(
                                             label: group.name,
                                             item: .guideGroup(group.id),
@@ -1202,8 +1230,34 @@ struct TVOSNavigation: View {
                                         }
                                     }
                                 }
-                                #endif
+                            } else {
+                                tvOSSidebarRow(
+                                    icon: tab.icon,
+                                    label: tab.label,
+                                    item: .tab(tab),
+                                    isSelected: appState.selectedTab == tab,
+                                    isCompact: true
+                                ) {
+                                    appState.guideGroupFilter = nil
+                                    appState.guideChannelFilter = ""
+                                    appState.selectedTab = tab
+                                    sidebarEnabled = false
+                                    focusedItem = nil
+                                } badge: { tvOSSidebarBadge(for: tab) }
                             }
+                            #else
+                            tvOSSidebarRow(
+                                icon: tab.icon,
+                                label: tab.label,
+                                item: .tab(tab),
+                                isSelected: appState.selectedTab == tab,
+                                isCompact: true
+                            ) {
+                                appState.selectedTab = tab
+                                sidebarEnabled = false
+                                focusedItem = nil
+                            } badge: { tvOSSidebarBadge(for: tab) }
+                            #endif
                         } else {
                             tvOSSidebarRow(
                                 icon: tab.icon,
@@ -1336,6 +1390,16 @@ struct TVOSNavigation: View {
             case .topicManage:
                 appState.showingKeywordsEditor = true
                 appState.selectedTab = .topics
+            #if DISPATCHERPVR
+            case .guideAll:
+                appState.guideGroupFilter = nil
+                appState.guideChannelFilter = ""
+                appState.selectedTab = .guide
+            case .guideGroup(let groupId):
+                appState.guideGroupFilter = groupId
+                appState.guideChannelFilter = ""
+                appState.selectedTab = .guide
+            #endif
             default:
                 break
             }
@@ -1385,6 +1449,8 @@ struct TVOSNavigation: View {
         case .topicManage:
             return "topic-manage"
         #if DISPATCHERPVR
+        case .guideAll:
+            return "guide-all"
         case .guideGroup(let groupId):
             return "guide-group-\(groupId)"
         #endif
@@ -1441,6 +1507,7 @@ enum TVSidebarItem: Hashable {
     case topicKeyword(String)
     case topicManage
     #if DISPATCHERPVR
+    case guideAll
     case guideGroup(Int)
     #endif
 }


### PR DESCRIPTION
Implements #49 — add channel groups (Sport, News, Kids, Movies, etc.) as sub-menus under the Guide menu item in the sidebar.

## What's new
- **Settings → Guide section** (Dispatcharr only): opt-in toggle + multi-select of which groups to show
- **iOS sidebar**: group sub-rows appear under Guide when enabled
- **tvOS sidebar**: group sub-rows under Guide when enabled
- Groups filtered to only show those with visible channels

## Files changed
- NexusPVR/Core/Models/UserPreferences.swift — guideShowGroupsInSidebar + guideGroupIds
- NexusPVR/Features/Settings/SettingsView.swift — settings UI
- NexusPVR/Navigation/NavigationRouter.swift — sidebar rendering

## Tested
- iOS build: ✅  
- tvOS build: ✅
- Demo mode confirms Guide view renders correctly