### PR TITLE
 tvOS invcremental scrubbing 1× → 2× → 4× → 8× #67

### DIFF
--- a/NexusPVR/Features/Player/MPVContainerView+tvOS.swift
+++ b/NexusPVR/Features/Player/MPVContainerView+tvOS.swift
@@ -59,12 +59,12 @@ struct MPVContainerView: UIViewRepresentable {
         view.onPlaybackEnded = onPlaybackEnded
         view.onVideoInfoUpdate = onVideoInfoUpdate
         view.onPlayPause = onTogglePlayPause
-        view.onSeekForward = {
-            view.seek(seconds: self.seekForwardTime)
+        view.onSeekForward = { multiplier in
+            view.seek(seconds: self.seekForwardTime * multiplier)
             self.onShowControls?()
         }
-        view.onSeekBackward = {
-            view.seek(seconds: -self.seekBackwardTime)
+        view.onSeekBackward = { multiplier in
+            view.seek(seconds: -self.seekBackwardTime * multiplier)
             self.onShowControls?()
         }
         view.onSelect = onToggleControls
@@ -81,12 +81,12 @@ struct MPVContainerView: UIViewRepresentable {
         view.onPlaybackEnded = onPlaybackEnded
         view.onVideoInfoUpdate = onVideoInfoUpdate
         view.onPlayPause = onTogglePlayPause
-        view.onSeekForward = {
-            view.seek(seconds: self.seekForwardTime)
+        view.onSeekForward = { multiplier in
+            view.seek(seconds: self.seekForwardTime * multiplier)
             self.onShowControls?()
         }
-        view.onSeekBackward = {
-            view.seek(seconds: -self.seekBackwardTime)
+        view.onSeekBackward = { multiplier in
+            view.seek(seconds: -self.seekBackwardTime * multiplier)
             self.onShowControls?()
         }
         view.onSelect = onToggleControls
@@ -103,12 +103,12 @@ struct MPVContainerView: UIViewRepresentable {
         view.onPlaybackEnded = onPlaybackEnded
         view.onVideoInfoUpdate = onVideoInfoUpdate
         view.onPlayPause = onTogglePlayPause
-        view.onSeekForward = {
-            view.seek(seconds: self.seekForwardTime)
+        view.onSeekForward = { multiplier in
+            view.seek(seconds: self.seekForwardTime * multiplier)
             self.onShowControls?()
         }
-        view.onSeekBackward = {
-            view.seek(seconds: -self.seekBackwardTime)
+        view.onSeekBackward = { multiplier in
+            view.seek(seconds: -self.seekBackwardTime * multiplier)
             self.onShowControls?()
         }
         view.onSelect = onToggleControls

--- a/NexusPVR/Features/Player/MPVPlayerGLView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerGLView.swift
@@ -29,8 +29,8 @@ class MPVPlayerGLView: GLKView {
     var recordingMonitor: MPVRecordingMonitor? { player?.recordingMonitor }
     #if os(tvOS)
     var onPlayPause: (() -> Void)?
-    var onSeekForward: (() -> Void)?
-    var onSeekBackward: (() -> Void)?
+    var onSeekForward: ((Int) -> Void)?
+    var onSeekBackward: ((Int) -> Void)?
     var onSelect: (() -> Void)?
     var onMenu: (() -> Void)?
     var onUpArrow: (() -> Void)?
@@ -218,22 +218,33 @@ class MPVPlayerGLView: GLKView {
     #if os(tvOS)
     private var seekTimer: Timer?
     private var seekDirection: Int = 0
+    private var seekTickCount: Int = 0
+
+    private func seekMultiplier(for tick: Int) -> Int {
+        // Hold-to-scrub acceleration: longer holds take bigger steps.
+        if tick < 8 { return 1 }
+        if tick < 16 { return 2 }
+        if tick < 28 { return 4 }
+        return 8
+    }
+
+    private func fireHoldSeek() {
+        let multiplier = seekMultiplier(for: seekTickCount)
+        if seekDirection < 0 {
+            onSeekBackward?(multiplier)
+        } else {
+            onSeekForward?(multiplier)
+        }
+        seekTickCount += 1
+    }
 
     private func startSeeking(direction: Int) {
         stopSeeking()
         seekDirection = direction
-        if direction < 0 {
-            onSeekBackward?()
-        } else {
-            onSeekForward?()
-        }
+        seekTickCount = 0
+        fireHoldSeek()
         seekTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            if self.seekDirection < 0 {
-                self.onSeekBackward?()
-            } else {
-                self.onSeekForward?()
-            }
+            self?.fireHoldSeek()
         }
     }
 
@@ -241,17 +252,18 @@ class MPVPlayerGLView: GLKView {
         seekTimer?.invalidate()
         seekTimer = nil
         seekDirection = 0
+        seekTickCount = 0
     }
 
     @objc private func handleSwipe(_ gesture: UISwipeGestureRecognizer) {
         switch gesture.direction {
         case .left:
             if onLeftArrow?() != true {
-                onSeekBackward?()
+                onSeekBackward?(1)
             }
         case .right:
             if onRightArrow?() != true {
-                onSeekForward?()
+                onSeekForward?(1)
             }
         case .up:
             onUpArrow?()

--- a/NexusPVR/Features/Player/MPVPlayerMetalView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerMetalView.swift
@@ -23,8 +23,8 @@ class MPVPlayerMetalView: UIView {
     #if os(tvOS)
     // tvOS remote control callbacks
     var onPlayPause: (() -> Void)?
-    var onSeekForward: (() -> Void)?
-    var onSeekBackward: (() -> Void)?
+    var onSeekForward: ((Int) -> Void)?
+    var onSeekBackward: ((Int) -> Void)?
     var onSelect: (() -> Void)?
     var onMenu: (() -> Void)?
     var onUpArrow: (() -> Void)?
@@ -173,22 +173,34 @@ class MPVPlayerMetalView: UIView {
     #if os(tvOS)
     private var seekTimer: Timer?
     private var seekDirection: Int = 0
+    private var seekTickCount: Int = 0
+
+    private func seekMultiplier(for tick: Int) -> Int {
+        // Hold-to-scrub acceleration: longer holds take bigger steps.
+        // Why: 1× steps require too many button-holds to traverse a recording.
+        if tick < 8 { return 1 }
+        if tick < 16 { return 2 }
+        if tick < 28 { return 4 }
+        return 8
+    }
+
+    private func fireHoldSeek() {
+        let multiplier = seekMultiplier(for: seekTickCount)
+        if seekDirection < 0 {
+            onSeekBackward?(multiplier)
+        } else {
+            onSeekForward?(multiplier)
+        }
+        seekTickCount += 1
+    }
 
     private func startSeeking(direction: Int) {
         stopSeeking()
         seekDirection = direction
-        if direction < 0 {
-            onSeekBackward?()
-        } else {
-            onSeekForward?()
-        }
+        seekTickCount = 0
+        fireHoldSeek()
         seekTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            if self.seekDirection < 0 {
-                self.onSeekBackward?()
-            } else {
-                self.onSeekForward?()
-            }
+            self?.fireHoldSeek()
         }
     }
 
@@ -196,17 +208,18 @@ class MPVPlayerMetalView: UIView {
         seekTimer?.invalidate()
         seekTimer = nil
         seekDirection = 0
+        seekTickCount = 0
     }
 
     @objc private func handleSwipe(_ gesture: UISwipeGestureRecognizer) {
         switch gesture.direction {
         case .left:
             if onLeftArrow?() != true {
-                onSeekBackward?()
+                onSeekBackward?(1)
             }
         case .right:
             if onRightArrow?() != true {
-                onSeekForward?()
+                onSeekForward?(1)
             }
         case .up:
             onUpArrow?()

--- a/NexusPVR/Features/Player/MPVPlayerPixelBufferView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerPixelBufferView.swift
@@ -24,8 +24,8 @@ class MPVPlayerPixelBufferView: UIView {
 
     #if os(tvOS)
     var onPlayPause: (() -> Void)?
-    var onSeekForward: (() -> Void)?
-    var onSeekBackward: (() -> Void)?
+    var onSeekForward: ((Int) -> Void)?
+    var onSeekBackward: ((Int) -> Void)?
     var onSelect: (() -> Void)?
     var onMenu: (() -> Void)?
     var onUpArrow: (() -> Void)?
@@ -170,22 +170,33 @@ class MPVPlayerPixelBufferView: UIView {
     #if os(tvOS)
     private var seekTimer: Timer?
     private var seekDirection: Int = 0
+    private var seekTickCount: Int = 0
+
+    private func seekMultiplier(for tick: Int) -> Int {
+        // Hold-to-scrub acceleration: longer holds take bigger steps.
+        if tick < 8 { return 1 }
+        if tick < 16 { return 2 }
+        if tick < 28 { return 4 }
+        return 8
+    }
+
+    private func fireHoldSeek() {
+        let multiplier = seekMultiplier(for: seekTickCount)
+        if seekDirection < 0 {
+            onSeekBackward?(multiplier)
+        } else {
+            onSeekForward?(multiplier)
+        }
+        seekTickCount += 1
+    }
 
     private func startSeeking(direction: Int) {
         stopSeeking()
         seekDirection = direction
-        if direction < 0 {
-            onSeekBackward?()
-        } else {
-            onSeekForward?()
-        }
+        seekTickCount = 0
+        fireHoldSeek()
         seekTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            if self.seekDirection < 0 {
-                self.onSeekBackward?()
-            } else {
-                self.onSeekForward?()
-            }
+            self?.fireHoldSeek()
         }
     }
 
@@ -193,6 +204,7 @@ class MPVPlayerPixelBufferView: UIView {
         seekTimer?.invalidate()
         seekTimer = nil
         seekDirection = 0
+        seekTickCount = 0
     }
 
     override func didMoveToWindow() {
@@ -209,11 +221,11 @@ class MPVPlayerPixelBufferView: UIView {
         switch gesture.direction {
         case .left:
             if onLeftArrow?() != true {
-                onSeekBackward?()
+                onSeekBackward?(1)
             }
         case .right:
             if onRightArrow?() != true {
-                onSeekForward?()
+                onSeekForward?(1)
             }
         case .up:
             onUpArrow?()


### PR DESCRIPTION
- MPVPlayerMetalView.swift, MPVPlayerGLView.swift, MPVPlayerPixelBufferView.swift (tvOS sections):
    - Changed onSeekForward/onSeekBackward from (() -> Void)? to ((Int) -> Void)? (multiplier).
    - Added seekTickCount and seekMultiplier(for:) that returns 1× → 2× → 4× → 8× based on hold duration (2s / 4s / 7s thresholds at the 0.25s tick rate).
    - startSeeking resets the tick counter, fires one immediate seek, then increments per tick.
    - Swipe gestures still pass multiplier 1 (single-step behavior unchanged).
  - MPVContainerView+tvOS.swift: the seek callbacks now multiply seekForwardTime/seekBackwardTime by the incoming multiplier.