### PR TITLE
feat(player): add mute button to video player controls (#80)

### DIFF
--- a/NexusPVR/Features/Player/MPVContainerView+iOS.swift
+++ b/NexusPVR/Features/Player/MPVContainerView+iOS.swift
@@ -39,6 +39,8 @@ struct MPVContainerView: UIViewRepresentable {
     @Binding var setAudioTrackFunc: ((Int) -> Void)?
     @Binding var setSubtitleTrackFunc: ((Int?) -> Void)?
     @Binding var getSubtitleTextFunc: (() -> String?)?
+    @Binding var setMutedFunc: ((Bool) -> Void)?
+    @Binding var isMuted: Bool
 
     private func configureCommonCallbacks(for view: MPVPlayerGLView) {
         view.setup(errorBinding: $errorMessage, isRecordingInProgress: isRecordingInProgress, recordingStartTime: recordingStartTime)
@@ -91,6 +93,8 @@ struct MPVContainerView: UIViewRepresentable {
             self.setAudioTrackFunc = { view.setAudioTrack($0) }
             self.setSubtitleTrackFunc = { view.setSubtitleTrack($0) }
             self.getSubtitleTextFunc = { view.getSubtitleText() }
+            self.setMutedFunc = { view.setMuted($0) }
+            self.isMuted = view.isMuted
         }
     }
 
@@ -109,6 +113,8 @@ struct MPVContainerView: UIViewRepresentable {
             self.setAudioTrackFunc = { view.setAudioTrack($0) }
             self.setSubtitleTrackFunc = { view.setSubtitleTrack($0) }
             self.getSubtitleTextFunc = { view.getSubtitleText() }
+            self.setMutedFunc = { view.setMuted($0) }
+            self.isMuted = view.isMuted
         }
     }
 
@@ -127,6 +133,8 @@ struct MPVContainerView: UIViewRepresentable {
             self.setAudioTrackFunc = { view.setAudioTrack($0) }
             self.setSubtitleTrackFunc = { view.setSubtitleTrack($0) }
             self.getSubtitleTextFunc = { view.getSubtitleText() }
+            self.setMutedFunc = { view.setMuted($0) }
+            self.isMuted = view.isMuted
         }
     }
 

--- a/NexusPVR/Features/Player/MPVContainerView+macOS.swift
+++ b/NexusPVR/Features/Player/MPVContainerView+macOS.swift
@@ -42,6 +42,8 @@ struct MPVContainerView: NSViewControllerRepresentable {
     @Binding var setAudioTrackFunc: ((Int) -> Void)?
     @Binding var setSubtitleTrackFunc: ((Int?) -> Void)?
     @Binding var getSubtitleTextFunc: (() -> String?)?
+    @Binding var setMutedFunc: ((Bool) -> Void)?
+    @Binding var isMuted: Bool
 
     func makeNSViewController(context: Context) -> NSViewController {
         let controller: NSViewController & MPVPlayerMacOSController
@@ -90,6 +92,8 @@ struct MPVContainerView: NSViewControllerRepresentable {
             self.setAudioTrackFunc = { controller.setAudioTrack($0) }
             self.setSubtitleTrackFunc = { controller.setSubtitleTrack($0) }
             self.getSubtitleTextFunc = { controller.getSubtitleText() }
+            self.setMutedFunc = { controller.setMuted($0) }
+            self.isMuted = controller.isMuted
         }
 
         return controller
@@ -139,6 +143,8 @@ protocol MPVPlayerMacOSController: AnyObject {
     func setAudioTrack(_ trackId: Int)
     func setSubtitleTrack(_ trackId: Int?)
     func getSubtitleText() -> String?
+    func setMuted(_ muted: Bool)
+    var isMuted: Bool { get }
 }
 
 // MARK: - MPVPlayerNSViewController (Metal)
@@ -221,6 +227,8 @@ final class MPVPlayerNSViewController: NSViewController, MPVPlayerMacOSControlle
     func setAudioTrack(_ trackId: Int) { player?.setAudioTrack(trackId) }
     func setSubtitleTrack(_ trackId: Int?) { player?.setSubtitleTrack(trackId) }
     func getSubtitleText() -> String? { player?.getSubtitleText() }
+    func setMuted(_ muted: Bool) { player?.setMuted(muted) }
+    var isMuted: Bool { player?.isMuted ?? false }
 
     func cleanup() {
         player?.destroy()
@@ -321,6 +329,8 @@ final class MPVPlayerPixelBufferNSViewController: NSViewController, MPVPlayerMac
     func setAudioTrack(_ trackId: Int) { player?.setAudioTrack(trackId) }
     func setSubtitleTrack(_ trackId: Int?) { player?.setSubtitleTrack(trackId) }
     func getSubtitleText() -> String? { player?.getSubtitleText() }
+    func setMuted(_ muted: Bool) { player?.setMuted(muted) }
+    var isMuted: Bool { player?.isMuted ?? false }
 
     func cleanup() {
         player?.destroy()
@@ -406,6 +416,8 @@ final class MPVPlayerNSOpenGLViewController: NSViewController, MPVPlayerMacOSCon
     func setAudioTrack(_ trackId: Int) { glView.setAudioTrack(trackId) }
     func setSubtitleTrack(_ trackId: Int?) { glView.setSubtitleTrack(trackId) }
     func getSubtitleText() -> String? { glView.getSubtitleText() }
+    func setMuted(_ muted: Bool) { glView.setMuted(muted) }
+    var isMuted: Bool { glView.isMuted }
 
     func cleanup() {
         glView.cleanup()
@@ -563,6 +575,8 @@ final class MPVPlayerMacOGLView: NSOpenGLView {
     func setAudioTrack(_ trackId: Int) { player?.setAudioTrack(trackId) }
     func setSubtitleTrack(_ trackId: Int?) { player?.setSubtitleTrack(trackId) }
     func getSubtitleText() -> String? { player?.getSubtitleText() }
+    func setMuted(_ muted: Bool) { player?.setMuted(muted) }
+    var isMuted: Bool { player?.isMuted ?? false }
 
     func cleanup() {
         needsDrawing = false

--- a/NexusPVR/Features/Player/MPVPlayerCore.swift
+++ b/NexusPVR/Features/Player/MPVPlayerCore.swift
@@ -323,6 +323,22 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
 
 
 
+    func setMuted(_ muted: Bool) {
+        guard let mpv = mpv else { return }
+        var flag: Int32 = muted ? 1 : 0
+        let result = mpv_set_property(mpv, "mute", MPV_FORMAT_FLAG, &flag)
+        if result < 0 {
+            print("MPV: Failed to set mute: \(result)")
+        }
+    }
+
+    var isMuted: Bool {
+        guard let mpv = mpv else { return false }
+        var flag: Int32 = 0
+        mpv_get_property(mpv, "mute", MPV_FORMAT_FLAG, &flag)
+        return flag != 0
+    }
+
     func getVideoInfo() -> (codec: String?, width: Int?, height: Int?, hwdec: String?, audioChannels: String?, droppedFrames: Int64, gamma: String?, fps: Double) {
         guard let mpv = mpv else { return (nil, nil, nil, nil, nil, 0, nil, 0) }
 

--- a/NexusPVR/Features/Player/MPVPlayerGLView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerGLView.swift
@@ -166,6 +166,9 @@ class MPVPlayerGLView: GLKView {
         player?.loadURL(url)
     }
 
+    func setMuted(_ muted: Bool) { player?.setMuted(muted) }
+    var isMuted: Bool { player?.isMuted ?? false }
+
     func setStreamHeaders(_ headers: [String: String]) {
         player?.setStreamHeaders(headers)
     }

--- a/NexusPVR/Features/Player/MPVPlayerMetalView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerMetalView.swift
@@ -129,6 +129,9 @@ class MPVPlayerMetalView: UIView {
         player?.loadURL(url)
     }
 
+    func setMuted(_ muted: Bool) { player?.setMuted(muted) }
+    var isMuted: Bool { player?.isMuted ?? false }
+
     func setStreamHeaders(_ headers: [String: String]) {
         player?.setStreamHeaders(headers)
     }

--- a/NexusPVR/Features/Player/MPVPlayerPixelBufferView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerPixelBufferView.swift
@@ -123,6 +123,9 @@ class MPVPlayerPixelBufferView: UIView {
         session.player?.loadURL(url)
     }
 
+    func setMuted(_ muted: Bool) { session.player?.setMuted(muted) }
+    var isMuted: Bool { session.player?.isMuted ?? false }
+
     func setStreamHeaders(_ headers: [String: String]) {
         session.player?.setStreamHeaders(headers)
     }

--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -68,6 +68,10 @@ struct PlayerView: View {
     @State private var setSubtitleTrackFunc: ((Int?) -> Void)?
     @State private var getSubtitleTextFunc: (() -> String?)?
     @State private var currentSubtitleText: String?
+    #if os(iOS) || os(macOS)
+    @State private var setMutedFunc: ((Bool) -> Void)?
+    @State private var isMuted = false
+    #endif
     #if os(tvOS)
     @State private var tvFocusedTrackIndex: Int = -1  // -1 = tabs focused, 0+ = track list index
     #endif
@@ -239,7 +243,9 @@ struct PlayerView: View {
                 getTrackListFunc: $getTrackListFunc,
                 setAudioTrackFunc: $setAudioTrackFunc,
                 setSubtitleTrackFunc: $setSubtitleTrackFunc,
-                getSubtitleTextFunc: $getSubtitleTextFunc
+                getSubtitleTextFunc: $getSubtitleTextFunc,
+                setMutedFunc: $setMutedFunc,
+                isMuted: $isMuted
             )
                 .ignoresSafeArea()
                 .onTapGesture {
@@ -288,7 +294,9 @@ struct PlayerView: View {
                 getTrackListFunc: $getTrackListFunc,
                 setAudioTrackFunc: $setAudioTrackFunc,
                 setSubtitleTrackFunc: $setSubtitleTrackFunc,
-                getSubtitleTextFunc: $getSubtitleTextFunc
+                getSubtitleTextFunc: $getSubtitleTextFunc,
+                setMutedFunc: $setMutedFunc,
+                isMuted: $isMuted
             )
                 .ignoresSafeArea()
                 .onTapGesture {
@@ -981,6 +989,21 @@ struct PlayerView: View {
                 .layoutPriority(0)
 
             Spacer()
+
+            #if os(iOS) || os(macOS)
+            Button {
+                isMuted.toggle()
+                setMutedFunc?(isMuted)
+                scheduleHideControls()
+            } label: {
+                Image(systemName: isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                    .padding(8)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("player-mute-button")
+            #endif
 
             #if os(iOS)
             if isUsingPixelBufferRenderer && pipIsSupported {


### PR DESCRIPTION
- Expose `setMuted`/`isMuted` via mpv's `mute` property in MPVPlayerCore
- Propagate mute controls through player views (GL, Metal, PixelBuffer)
- Add mute toggle button in PlayerView topBar for iOS/macOS only