### PR TITLE
fix(tvOS,PlayerView): pause icon stays after panel dismiss via remote #82

### DIFF
--- a/NexusPVR/Features/Player/MPVContainerView+tvOS.swift
+++ b/NexusPVR/Features/Player/MPVContainerView+tvOS.swift
@@ -48,6 +48,7 @@ struct MPVContainerView: UIViewRepresentable {
     @Binding var tvFocusedTrackIndex: Int
     var tvTrackCountProvider: (() -> Int)?
     var tvSelectTrack: (() -> Void)?
+    var onDismissSettingsPanel: (() -> Void)?
 
     private func configureCommonCallbacks(for view: MPVPlayerMetalView) {
         view.onPositionUpdate = { position, dur in
@@ -274,36 +275,40 @@ struct MPVContainerView: UIViewRepresentable {
         let focusBinding = $tvFocusedTrackIndex
         let openSettings = onOpenSettings
         view.onUpArrow = openSettings
+        let dismissPanel = onDismissSettingsPanel
         view.onMenuOverride = {
             print("[tvOS] onMenuOverride called, panelOpen=\(panelBinding.wrappedValue)")
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.25)) { panelBinding.wrappedValue = false }
-            focusBinding.wrappedValue = -1
+            withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
             return true
         }
         view.onLeftArrow = {
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                switch tabBinding.wrappedValue {
-                case .video:
-                    withAnimation(.easeInOut(duration: 0.25)) { panelBinding.wrappedValue = false }
-                case .audio: tabBinding.wrappedValue = .video
-                case .subtitles: tabBinding.wrappedValue = .audio
-                }
+            switch tabBinding.wrappedValue {
+            case .video:
+                withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
+            case .audio:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .video }
+                focusBinding.wrappedValue = -1
+            case .subtitles:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .audio }
+                focusBinding.wrappedValue = -1
             }
-            focusBinding.wrappedValue = -1
             return true
         }
         view.onRightArrow = {
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                switch tabBinding.wrappedValue {
-                case .video: tabBinding.wrappedValue = .audio
-                case .audio: tabBinding.wrappedValue = .subtitles
-                case .subtitles: break
-                }
+            switch tabBinding.wrappedValue {
+            case .video:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .audio }
+                focusBinding.wrappedValue = -1
+            case .audio:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .subtitles }
+                focusBinding.wrappedValue = -1
+            case .subtitles:
+                // Right-click on the last tab dismisses the panel (mirrors left-click on .video)
+                withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
             }
-            focusBinding.wrappedValue = -1
             return true
         }
         view.onDownArrow = {
@@ -327,36 +332,40 @@ struct MPVContainerView: UIViewRepresentable {
         let focusBinding = $tvFocusedTrackIndex
         let openSettings = onOpenSettings
         view.onUpArrow = openSettings
+        let dismissPanel = onDismissSettingsPanel
         view.onMenuOverride = {
             print("[tvOS] onMenuOverride called, panelOpen=\(panelBinding.wrappedValue)")
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.25)) { panelBinding.wrappedValue = false }
-            focusBinding.wrappedValue = -1
+            withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
             return true
         }
         view.onLeftArrow = {
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                switch tabBinding.wrappedValue {
-                case .video:
-                    withAnimation(.easeInOut(duration: 0.25)) { panelBinding.wrappedValue = false }
-                case .audio: tabBinding.wrappedValue = .video
-                case .subtitles: tabBinding.wrappedValue = .audio
-                }
+            switch tabBinding.wrappedValue {
+            case .video:
+                withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
+            case .audio:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .video }
+                focusBinding.wrappedValue = -1
+            case .subtitles:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .audio }
+                focusBinding.wrappedValue = -1
             }
-            focusBinding.wrappedValue = -1
             return true
         }
         view.onRightArrow = {
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                switch tabBinding.wrappedValue {
-                case .video: tabBinding.wrappedValue = .audio
-                case .audio: tabBinding.wrappedValue = .subtitles
-                case .subtitles: break
-                }
+            switch tabBinding.wrappedValue {
+            case .video:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .audio }
+                focusBinding.wrappedValue = -1
+            case .audio:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .subtitles }
+                focusBinding.wrappedValue = -1
+            case .subtitles:
+                // Right-click on the last tab dismisses the panel (mirrors left-click on .video)
+                withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
             }
-            focusBinding.wrappedValue = -1
             return true
         }
         view.onDownArrow = {
@@ -380,36 +389,40 @@ struct MPVContainerView: UIViewRepresentable {
         let focusBinding = $tvFocusedTrackIndex
         let openSettings = onOpenSettings
         view.onUpArrow = openSettings
+        let dismissPanel = onDismissSettingsPanel
         view.onMenuOverride = {
             print("[tvOS] onMenuOverride called, panelOpen=\(panelBinding.wrappedValue)")
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.25)) { panelBinding.wrappedValue = false }
-            focusBinding.wrappedValue = -1
+            withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
             return true
         }
         view.onLeftArrow = {
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                switch tabBinding.wrappedValue {
-                case .video:
-                    withAnimation(.easeInOut(duration: 0.25)) { panelBinding.wrappedValue = false }
-                case .audio: tabBinding.wrappedValue = .video
-                case .subtitles: tabBinding.wrappedValue = .audio
-                }
+            switch tabBinding.wrappedValue {
+            case .video:
+                withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
+            case .audio:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .video }
+                focusBinding.wrappedValue = -1
+            case .subtitles:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .audio }
+                focusBinding.wrappedValue = -1
             }
-            focusBinding.wrappedValue = -1
             return true
         }
         view.onRightArrow = {
             guard panelBinding.wrappedValue else { return false }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                switch tabBinding.wrappedValue {
-                case .video: tabBinding.wrappedValue = .audio
-                case .audio: tabBinding.wrappedValue = .subtitles
-                case .subtitles: break
-                }
+            switch tabBinding.wrappedValue {
+            case .video:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .audio }
+                focusBinding.wrappedValue = -1
+            case .audio:
+                withAnimation(.easeInOut(duration: 0.15)) { tabBinding.wrappedValue = .subtitles }
+                focusBinding.wrappedValue = -1
+            case .subtitles:
+                // Right-click on the last tab dismisses the panel (mirrors left-click on .video)
+                withAnimation(.easeInOut(duration: 0.25)) { dismissPanel?() }
             }
-            focusBinding.wrappedValue = -1
             return true
         }
         view.onDownArrow = {

--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -200,7 +200,11 @@ struct PlayerView: View {
                 settingsTab: $settingsTab,
                 tvFocusedTrackIndex: $tvFocusedTrackIndex,
                 tvTrackCountProvider: { tvTrackCount },
-                tvSelectTrack: { tvSelectFocusedTrack() }
+                tvSelectTrack: { tvSelectFocusedTrack() },
+                onDismissSettingsPanel: {
+                    dismissSettingsPanel()  // sets showSettingsPanel = false AND re-schedules hide
+                    tvFocusedTrackIndex = -1
+                }
             )
                 .ignoresSafeArea()
             #elseif os(iOS)
@@ -607,6 +611,9 @@ struct PlayerView: View {
         #if os(tvOS)
         .onChange(of: showSettingsPanel) { _ in
             appState.tvosPlayerSettingsPanelOpen = showSettingsPanel
+            if !showSettingsPanel {
+                scheduleHideControls()  // always re-arm auto-hide when the panel closes
+            }
         }
         #endif
         .onChange(of: duration) { _ in


### PR DESCRIPTION
- Add onDismissSettingsPanel closure to centralize panel dismissal for all three renderers
- Route onMenuOverride and onLeftArrow callbacks through dismissSettingsPanel() to re-arm auto-hide
- Add defensive .onChange handler to re-arm hide timer whenever showSettingsPanel becomes false
- Right-click on last tab (.subtitles) now dismisses panel to match left-click on .video behavior