### PR TITLE
Implement channel summary API for Dispatcharr variant #88

### DIFF
--- a/NexusPVR/Core/Services/DispatcherClient.swift
+++ b/NexusPVR/Core/Services/DispatcherClient.swift
@@ -940,6 +940,84 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         return items.map { $0.toChannel() }
     }
 
+    func getChannelSummary(profileId: Int? = nil) async throws -> [Channel] {
+        guard !config.isDemoMode else { return DemoDataProvider.channels }
+        if useOutputEndpoints {
+            return try await getChannels()
+        }
+
+        var components = URLComponents(string: "\(baseURL)/api/channels/channels/summary/")!
+        var queryItems = [URLQueryItem(name: "page_size", value: "10000")]
+        if let profileId {
+            queryItems.append(URLQueryItem(name: "channel_profile_id", value: String(profileId)))
+        }
+        components.queryItems = queryItems
+        guard let url = components.url else {
+            throw PVRClientError.invalidResponse
+        }
+
+        let channelsStart = CFAbsoluteTimeGetCurrent()
+        let items: [DispatcharrChannel] = try await fetchAllPages(url)
+        print("[Dispatcharr] Fetched \(items.count) channel summaries in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - channelsStart) * 1000))ms")
+
+        tvgIdToChannelId = [:]
+        channelIdToLogoId = [:]
+        channelIdToUUID = [:]
+        for ch in items {
+            if let logoId = ch.logoId {
+                channelIdToLogoId[ch.id] = logoId
+            }
+            if let uuid = ch.uuid, !uuid.isEmpty {
+                channelIdToUUID[ch.id] = uuid
+            }
+        }
+
+        let epgResolveStart = CFAbsoluteTimeGetCurrent()
+        let channelsNeedingResolve = items.filter { $0.epgDataId != nil }
+        let concurrencyLimit = 20
+        let resolvedMappings = await withTaskGroup(of: (Int, String?).self) { group in
+            var results = [(Int, String?)]()
+            var index = 0
+
+            for ch in channelsNeedingResolve {
+                guard let epgDataId = ch.epgDataId else { continue }
+                guard let epgURL = URL(string: "\(baseURL)/api/epg/epgdata/\(epgDataId)/") else { continue }
+
+                if index >= concurrencyLimit {
+                    if let result = await group.next() {
+                        results.append(result)
+                    }
+                }
+
+                let channelId = ch.id
+                group.addTask { [weak self] in
+                    guard let self else { return (channelId, nil) }
+                    do {
+                        let epgData: DispatcharrEPGData = try await self.authenticatedRequest(epgURL)
+                        return (channelId, epgData.tvgId)
+                    } catch {
+                        return (channelId, nil)
+                    }
+                }
+                index += 1
+            }
+
+            for await result in group {
+                results.append(result)
+            }
+            return results
+        }
+        for (channelId, epgTvgId) in resolvedMappings {
+            if let epgTvgId, !epgTvgId.isEmpty,
+               tvgIdToChannelId[epgTvgId] == nil {
+                tvgIdToChannelId[epgTvgId] = channelId
+            }
+        }
+        print("[Dispatcharr] Resolved \(channelsNeedingResolve.count) summary EPG data mappings in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - epgResolveStart) * 1000))ms")
+
+        return items.map { $0.toChannel() }
+    }
+
     func getChannelProfiles() async throws -> [ChannelProfile] {
         guard !config.isDemoMode else { return DemoDataProvider.channelProfiles }
         if useOutputEndpoints { return [] }

--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -38,7 +38,7 @@ final class EPGCache: ObservableObject {
 
     // MARK: - Loading
 
-    func loadData(using client: PVRClient) async {
+    func loadData(using client: PVRClient, profileId: Int? = nil) async {
         // Prevent concurrent loads
         guard !isLoadInProgress else { return }
         guard client.isConfigured else {
@@ -49,7 +49,11 @@ final class EPGCache: ObservableObject {
         backgroundLoadTask?.cancel()
         isLoadInProgress = true
         isLoading = true
+        hasLoaded = false
+        isFullyLoaded = false
         error = nil
+        epg = [:]
+        loadedDays = []
         let totalStart = CFAbsoluteTimeGetCurrent()
 
         do {
@@ -61,7 +65,11 @@ final class EPGCache: ObservableObject {
 
             // Fetch all channels
             let channelsStart = CFAbsoluteTimeGetCurrent()
+            #if DISPATCHERPVR
+            let loaded = try await client.getChannelSummary(profileId: profileId)
+            #else
             let loaded = try await client.getChannels()
+            #endif
             let sorted = loaded.sorted { $0.number < $1.number }
             channels = sorted
             channelMap = Dictionary(sorted.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
@@ -151,6 +159,11 @@ final class EPGCache: ObservableObject {
         }
     }
 
+    func reloadData(using client: PVRClient, profileId: Int? = nil) async {
+        invalidate()
+        await loadData(using: client, profileId: profileId)
+    }
+
     /// Ensure EPG data for a specific day is loaded.
     /// If the background full-EPG task is still running, await it instead of issuing a redundant fetch.
     func ensureDay(_ date: Date, using client: PVRClient) async {
@@ -197,6 +210,9 @@ final class EPGCache: ObservableObject {
     // MARK: - Channel Filtering
 
     func channels(inProfile profileId: Int?) -> [Channel] {
+        // When Dispatcharr channels were loaded through the summary endpoint
+        // with a profile id, this should already be narrowed server-side.
+        // Keep this as a screen-level fallback for cached/all-channel data.
         guard let profileId,
               let profile = channelProfiles.first(where: { $0.id == profileId }) else {
             return visibleChannels

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -120,6 +120,15 @@ struct GuideView: View {
             .onChange(of: appState.guideGroupFilter) {
                 Task { viewModel.selectedGroupId = appState.guideGroupFilter }
             }
+            #if DISPATCHERPVR
+            .onChange(of: viewModel.selectedProfileId) { _, profileId in
+                Task {
+                    await epgCache.reloadData(using: client, profileId: profileId)
+                    viewModel.showChannelSearch = epgCache.channels.count > 25
+                    viewModel.updateKeywordMatches(keywords: keywords)
+                }
+            }
+            #endif
             .onChange(of: scenePhase) {
                 if scenePhase == .active {
                     Task { await refreshRecordings() }

--- a/NexusPVR/Features/LiveTV/LiveTVViewModel.swift
+++ b/NexusPVR/Features/LiveTV/LiveTVViewModel.swift
@@ -46,7 +46,11 @@ final class LiveTVViewModel: ObservableObject {
                 try await client.authenticate()
             }
 
+            #if DISPATCHERPVR
+            channels = try await client.getChannelSummary()
+            #else
             channels = try await client.getChannels()
+            #endif
             channels.sort { $0.number < $1.number }
 
             // Load current programs for each channel


### PR DESCRIPTION
Add getChannelSummary endpoint returning channels with optional profile filter. Update EPGCache to accept profileId and reload data when profile changes. Use summary API for channel list in LiveTVViewModel.