### PR TITLE
Support shared dummy EPG sources with multi-channel mapping #86

### DIFF
--- a/NexusPVR/Core/Services/DispatcharrProgram.swift
+++ b/NexusPVR/Core/Services/DispatcharrProgram.swift
@@ -17,6 +17,7 @@ nonisolated struct DispatcharrProgram: Decodable, Sendable {
     let description: String?
     let tvgId: String?
     let channel: Int?
+    let epgDataId: Int?
     let season: Int?
     let episode: Int?
     let bannerURL: String?
@@ -30,6 +31,7 @@ nonisolated struct DispatcharrProgram: Decodable, Sendable {
         case description
         case tvgId = "tvg_id"
         case channel
+        case epgDataId = "epg_data_id"
         case season
         case episode
     }
@@ -67,6 +69,15 @@ nonisolated struct DispatcharrProgram: Decodable, Sendable {
             channel = parsed
         } else {
             channel = nil
+        }
+
+        if let intEpgDataId = try? container.decode(Int.self, forKey: .epgDataId) {
+            epgDataId = intEpgDataId
+        } else if let stringEpgDataId = try? container.decodeIfPresent(String.self, forKey: .epgDataId),
+                  let parsed = Int(stringEpgDataId) {
+            epgDataId = parsed
+        } else {
+            epgDataId = nil
         }
 
         season = try container.decodeIfPresent(Int.self, forKey: .season)
@@ -147,4 +158,69 @@ nonisolated struct DispatcharrProgram: Decodable, Sendable {
         )
     }
 
+}
+
+nonisolated enum DispatcharrEPGProgramMapper {
+    static func map(
+        programs: [DispatcharrProgram],
+        tvgIdToChannelIds: [String: [Int]],
+        epgDataIdToChannelIds: [Int: [Int]],
+        sortByStart: Bool
+    ) -> [Int: [Program]] {
+        var mapped = [Int: [Program]]()
+
+        for program in programs {
+            let channelIds = resolvedChannelIds(
+                for: program,
+                tvgIdToChannelIds: tvgIdToChannelIds,
+                epgDataIdToChannelIds: epgDataIdToChannelIds
+            )
+            guard !channelIds.isEmpty else { continue }
+
+            for channelId in channelIds {
+                guard let mappedProgram = program.toProgram(channelId: channelId) else { continue }
+                mapped[channelId, default: []].append(mappedProgram)
+            }
+        }
+
+        if sortByStart {
+            for (channelId, programs) in mapped {
+                mapped[channelId] = programs.sorted { $0.start < $1.start }
+            }
+        }
+
+        return mapped
+    }
+
+    private static func resolvedChannelIds(
+        for program: DispatcharrProgram,
+        tvgIdToChannelIds: [String: [Int]],
+        epgDataIdToChannelIds: [Int: [Int]]
+    ) -> [Int] {
+        if let directId = program.channel {
+            return [directId]
+        }
+
+        if let epgDataId = program.epgDataId,
+           let channelIds = epgDataIdToChannelIds[epgDataId],
+           !channelIds.isEmpty {
+            return channelIds
+        }
+
+        if let tvgId = program.tvgId,
+           !tvgId.isEmpty,
+           let channelIds = tvgIdToChannelIds[tvgId] {
+            return channelIds
+        }
+
+        return []
+    }
+}
+
+extension Array where Element: Equatable {
+    mutating func appendIfMissing(_ element: Element) {
+        if !contains(element) {
+            append(element)
+        }
+    }
 }

--- a/NexusPVR/Core/Services/DispatcherClient.swift
+++ b/NexusPVR/Core/Services/DispatcherClient.swift
@@ -23,8 +23,11 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
     private var authInProgress: Task<Void, Error>?
     private let session: URLSession
     private let networkEventLogger: any NetworkEventLogging
-    /// Maps tvg_id (e.g. "TSN1.ca") → channel id for EPG lookups
-    private var tvgIdToChannelId: [String: Int] = [:]
+    /// Maps tvg_id (e.g. "TSN1.ca") → channel ids for EPG lookups.
+    /// Multiple live-event channels can share the same dummy EPG source/tvg_id.
+    private var tvgIdToChannelIds: [String: [Int]] = [:]
+    /// Maps Dispatcharr epg_data_id → channel ids for dummy-source EPG lookups.
+    private var epgDataIdToChannelIds: [Int: [Int]] = [:]
     /// Maps channel id → logo id for icon URLs
     private var channelIdToLogoId: [Int: Int] = [:]
     /// Maps channel id → UUID for stream URLs
@@ -66,6 +69,8 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         refreshToken = nil
         useApiKeyAuth = false
         useOutputEndpoints = false
+        tvgIdToChannelIds = [:]
+        epgDataIdToChannelIds = [:]
         isAuthenticated = false
     }
 
@@ -877,18 +882,23 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         print("[Dispatcharr] Fetched \(items.count) channels in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - channelsStart) * 1000))ms")
 
         // Build lookup maps for EPG, logo, and stream URL resolution
-        tvgIdToChannelId = [:]
+        tvgIdToChannelIds = [:]
+        epgDataIdToChannelIds = [:]
         channelIdToLogoId = [:]
         channelIdToUUID = [:]
         for ch in items {
             if let tvgId = ch.tvgId, !tvgId.isEmpty {
-                tvgIdToChannelId[tvgId] = ch.id
+                tvgIdToChannelIds[tvgId, default: []].appendIfMissing(ch.id)
+            }
+            if let epgDataId = ch.epgDataId {
+                epgDataIdToChannelIds[epgDataId, default: []].appendIfMissing(ch.id)
             }
             if let logoId = ch.logoId {
                 channelIdToLogoId[ch.id] = logoId
             }
             if let uuid = ch.uuid, !uuid.isEmpty {
                 channelIdToUUID[ch.id] = uuid
+                tvgIdToChannelIds[uuid, default: []].appendIfMissing(ch.id)
             }
         }
 
@@ -930,9 +940,8 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
             return results
         }
         for (channelId, epgTvgId) in resolvedMappings {
-            if let epgTvgId, !epgTvgId.isEmpty,
-               tvgIdToChannelId[epgTvgId] == nil {
-                tvgIdToChannelId[epgTvgId] = channelId
+            if let epgTvgId, !epgTvgId.isEmpty {
+                tvgIdToChannelIds[epgTvgId, default: []].appendIfMissing(channelId)
             }
         }
         print("[Dispatcharr] Resolved \(channelsNeedingResolve.count) EPG data mappings in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - epgResolveStart) * 1000))ms")
@@ -960,15 +969,23 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         let items: [DispatcharrChannel] = try await fetchAllPages(url)
         print("[Dispatcharr] Fetched \(items.count) channel summaries in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - channelsStart) * 1000))ms")
 
-        tvgIdToChannelId = [:]
+        tvgIdToChannelIds = [:]
+        epgDataIdToChannelIds = [:]
         channelIdToLogoId = [:]
         channelIdToUUID = [:]
         for ch in items {
+            if let tvgId = ch.tvgId, !tvgId.isEmpty {
+                tvgIdToChannelIds[tvgId, default: []].appendIfMissing(ch.id)
+            }
+            if let epgDataId = ch.epgDataId {
+                epgDataIdToChannelIds[epgDataId, default: []].appendIfMissing(ch.id)
+            }
             if let logoId = ch.logoId {
                 channelIdToLogoId[ch.id] = logoId
             }
             if let uuid = ch.uuid, !uuid.isEmpty {
                 channelIdToUUID[ch.id] = uuid
+                tvgIdToChannelIds[uuid, default: []].appendIfMissing(ch.id)
             }
         }
 
@@ -1008,9 +1025,8 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
             return results
         }
         for (channelId, epgTvgId) in resolvedMappings {
-            if let epgTvgId, !epgTvgId.isEmpty,
-               tvgIdToChannelId[epgTvgId] == nil {
-                tvgIdToChannelId[epgTvgId] = channelId
+            if let epgTvgId, !epgTvgId.isEmpty {
+                tvgIdToChannelIds[epgTvgId, default: []].appendIfMissing(channelId)
             }
         }
         print("[Dispatcharr] Resolved \(channelsNeedingResolve.count) summary EPG data mappings in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - epgResolveStart) * 1000))ms")
@@ -1046,7 +1062,8 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
             throw PVRClientError.invalidResponse
         }
 
-        let tvgId = tvgIdToChannelId.first(where: { $0.value == channelId })?.key
+        let tvgIds = Set(tvgIdToChannelIds.compactMap { $0.value.contains(channelId) ? $0.key : nil })
+        let epgDataIds = Set(epgDataIdToChannelIds.compactMap { $0.value.contains(channelId) ? $0.key : nil })
 
         let allPrograms: [DispatcharrProgram] = try await fetchAllPages(url, maxPages: 50)
         let programs = allPrograms
@@ -1054,7 +1071,10 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
                 if let directId = program.channel, directId == channelId {
                     return true
                 }
-                if let tvgId, let programTvgId = program.tvgId, programTvgId == tvgId {
+                if let epgDataId = program.epgDataId, epgDataIds.contains(epgDataId) {
+                    return true
+                }
+                if let programTvgId = program.tvgId, tvgIds.contains(programTvgId) {
                     return true
                 }
                 return false
@@ -1079,28 +1099,16 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         }
         let start = CFAbsoluteTimeGetCurrent()
         let data = try await authenticatedRequestData(url)
-        let tvgMap = tvgIdToChannelId
+        let tvgMap = tvgIdToChannelIds
+        let epgDataMap = epgDataIdToChannelIds
         let result: [Int: [Program]] = try await Task.detached(priority: .userInitiated) {
             let wrapper = try JSONDecoder().decode(EPGGridResponse.self, from: data)
-            var mapped = [Int: [Program]]()
-            for program in wrapper.data {
-                let resolvedId: Int?
-                if let directId = program.channel {
-                    resolvedId = directId
-                } else if let tvgId = program.tvgId, !tvgId.isEmpty {
-                    resolvedId = tvgMap[tvgId]
-                } else {
-                    resolvedId = nil
-                }
-                guard let cid = resolvedId else { continue }
-                guard let p = program.toProgram(channelId: cid) else { continue }
-                mapped[cid, default: []].append(p)
-            }
-            // Sort each channel's programs by start time so cache.programs(for:on:) sees ordered data.
-            for (k, v) in mapped {
-                mapped[k] = v.sorted { $0.start < $1.start }
-            }
-            return mapped
+            return DispatcharrEPGProgramMapper.map(
+                programs: wrapper.data,
+                tvgIdToChannelIds: tvgMap,
+                epgDataIdToChannelIds: epgDataMap,
+                sortByStart: true
+            )
         }.value
         let count = result.values.reduce(0) { $0 + $1.count }
         print("[Dispatcharr] Grid: \(count) programs across \(result.count) channels in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - start) * 1000))ms")
@@ -1124,23 +1132,15 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         let allPrograms: [DispatcharrProgram] = try await fetchAllPages(url, maxPages: 50)
 
 
-        let tvgMap = tvgIdToChannelId
+        let tvgMap = tvgIdToChannelIds
+        let epgDataMap = epgDataIdToChannelIds
         let result = await Task.detached(priority: .userInitiated) {
-            var mapped = [Int: [Program]]()
-            for program in allPrograms {
-                let channelId: Int?
-                if let directId = program.channel {
-                    channelId = directId
-                } else if let tvgId = program.tvgId, !tvgId.isEmpty {
-                    channelId = tvgMap[tvgId]
-                } else {
-                    channelId = nil
-                }
-                guard let resolvedId = channelId else { continue }
-                guard let p = program.toProgram(channelId: resolvedId) else { continue }
-                mapped[resolvedId, default: []].append(p)
-            }
-            return mapped
+            DispatcharrEPGProgramMapper.map(
+                programs: allPrograms,
+                tvgIdToChannelIds: tvgMap,
+                epgDataIdToChannelIds: epgDataMap,
+                sortByStart: false
+            )
         }.value
 
         return result
@@ -1281,7 +1281,7 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
                 return tvgId
             }
             if let channelId = program.channel {
-                return tvgIdToChannelId.first(where: { $0.value == channelId })?.key
+                return tvgIdToChannelIds.first(where: { $0.value.contains(channelId) })?.key
             }
             return nil
         }()
@@ -1380,7 +1380,7 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
                 RecurringRecording(
                     id: recurringId,
                     name: title,
-                    channelID: tvgIdToChannelId[tvgId],
+                    channelID: tvgIdToChannelIds[tvgId]?.first,
                     channel: nil,
                     enabled: response.success ?? true
                 )
@@ -1417,7 +1417,7 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         if let directId = program.channel {
             return directId
         }
-        if let tvgId = program.tvgId, let mappedId = tvgIdToChannelId[tvgId] {
+        if let tvgId = program.tvgId, let mappedId = tvgIdToChannelIds[tvgId]?.first {
             return mappedId
         }
         if let fallbackChannelId {

--- a/NexusPVR/Core/Services/LiveProgramFetcher.swift
+++ b/NexusPVR/Core/Services/LiveProgramFetcher.swift
@@ -211,11 +211,13 @@ enum LiveProgramFetcher {
         let name: String
         let tvgId: String?
         let epgDataId: Int?
+        let uuid: String?
 
         enum CodingKeys: String, CodingKey {
             case id, name
             case tvgId = "tvg_id"
             case epgDataId = "epg_data_id"
+            case uuid
         }
 
         init(from decoder: Decoder) throws {
@@ -229,7 +231,15 @@ enum LiveProgramFetcher {
             }
             name = try container.decode(String.self, forKey: .name)
             tvgId = try container.decodeIfPresent(String.self, forKey: .tvgId)
-            epgDataId = try container.decodeIfPresent(Int.self, forKey: .epgDataId)
+            uuid = try container.decodeIfPresent(String.self, forKey: .uuid)
+            if let intEpgDataId = try? container.decode(Int.self, forKey: .epgDataId) {
+                epgDataId = intEpgDataId
+            } else if let stringEpgDataId = try? container.decode(String.self, forKey: .epgDataId),
+                      let parsed = Int(stringEpgDataId) {
+                epgDataId = parsed
+            } else {
+                epgDataId = nil
+            }
         }
     }
 
@@ -247,6 +257,7 @@ enum LiveProgramFetcher {
         let end: String
         let tvgId: String?
         let channel: Int?
+        let epgDataId: Int?
 
         enum CodingKeys: String, CodingKey {
             case id, title, description
@@ -256,6 +267,7 @@ enum LiveProgramFetcher {
             case start, end
             case tvgId = "tvg_id"
             case channel
+            case epgDataId = "epg_data_id"
         }
 
         init(from decoder: Decoder) throws {
@@ -282,6 +294,14 @@ enum LiveProgramFetcher {
                 channel = parsed
             } else {
                 channel = nil
+            }
+            if let intEpgDataId = try? container.decode(Int.self, forKey: .epgDataId) {
+                epgDataId = intEpgDataId
+            } else if let stringEpgDataId = try? container.decode(String.self, forKey: .epgDataId),
+                      let parsed = Int(stringEpgDataId) {
+                epgDataId = parsed
+            } else {
+                epgDataId = nil
             }
         }
     }
@@ -314,7 +334,7 @@ enum LiveProgramFetcher {
 
     private static func fetchDispatcharrChannelsAndPrograms(
         config: ServerConfig, session: URLSession, token: String
-    ) async throws -> (channels: [SimpleChannel], programs: [SimpleProgram], tvgIdMap: [String: Int]) {
+    ) async throws -> (channels: [SimpleChannel], programs: [SimpleProgram], tvgIdMap: [String: [Int]], epgDataIdMap: [Int: [Int]]) {
         // Fetch channels and EPG in parallel
         async let channelsTask: [SimpleChannel] = {
             guard let url = URL(string: "\(config.baseURL)/api/channels/channels/?page_size=10000") else { return [] }
@@ -337,11 +357,18 @@ enum LiveProgramFetcher {
         let channels = try await channelsTask
         let programs = try await programsTask
 
-        // Build tvg_id → channelId map (from channel's own tvg_id)
-        var tvgIdMap: [String: Int] = [:]
+        // Build tvg_id / epg_data_id → channelIds maps. Live-event dummy sources can be shared.
+        var tvgIdMap: [String: [Int]] = [:]
+        var epgDataIdMap: [Int: [Int]] = [:]
         for ch in channels {
             if let tvgId = ch.tvgId, !tvgId.isEmpty {
-                tvgIdMap[tvgId] = ch.id
+                appendIfMissing(ch.id, to: &tvgIdMap[tvgId, default: []])
+            }
+            if let uuid = ch.uuid, !uuid.isEmpty {
+                appendIfMissing(ch.id, to: &tvgIdMap[uuid, default: []])
+            }
+            if let epgDataId = ch.epgDataId {
+                appendIfMissing(ch.id, to: &epgDataIdMap[epgDataId, default: []])
             }
         }
 
@@ -367,23 +394,31 @@ enum LiveProgramFetcher {
                     }
                 }
                 for await (channelId, epgTvgId) in group {
-                    if let epgTvgId, !epgTvgId.isEmpty, tvgIdMap[epgTvgId] == nil {
-                        tvgIdMap[epgTvgId] = channelId
+                    if let epgTvgId, !epgTvgId.isEmpty {
+                        appendIfMissing(channelId, to: &tvgIdMap[epgTvgId, default: []])
                     }
                 }
             }
         }
 
-        return (channels, programs, tvgIdMap)
+        return (channels, programs, tvgIdMap, epgDataIdMap)
     }
 
     private static func resolveChannelId(
         program: SimpleProgram,
-        tvgIdToChannelId: [String: Int]
+        tvgIdToChannelIds: [String: [Int]],
+        epgDataIdToChannelIds: [Int: [Int]]
     ) -> Int? {
         if let directId = program.channel { return directId }
-        if let tvgId = program.tvgId, let mapped = tvgIdToChannelId[tvgId] { return mapped }
+        if let epgDataId = program.epgDataId, let mapped = epgDataIdToChannelIds[epgDataId]?.first { return mapped }
+        if let tvgId = program.tvgId, let mapped = tvgIdToChannelIds[tvgId]?.first { return mapped }
         return nil
+    }
+
+    private static func appendIfMissing(_ channelId: Int, to channelIds: inout [Int]) {
+        if !channelIds.contains(channelId) {
+            channelIds.append(channelId)
+        }
     }
 
     private static func fetchDispatcharrByKeywords(
@@ -391,7 +426,7 @@ enum LiveProgramFetcher {
         keywords: [String], excludeChannelIds: Set<Int>, limit: Int
     ) async throws -> [TopShelfProgram] {
         let token = try await authenticateDispatcharr(config: config, session: session)
-        let (channels, programs, tvgIdToChannelId) = try await fetchDispatcharrChannelsAndPrograms(config: config, session: session, token: token)
+        let (channels, programs, tvgIdToChannelIds, epgDataIdToChannelIds) = try await fetchDispatcharrChannelsAndPrograms(config: config, session: session, token: token)
 
         let channelMap = Dictionary(uniqueKeysWithValues: channels.map { ($0.id, $0.name) })
 
@@ -404,7 +439,7 @@ enum LiveProgramFetcher {
         var seenChannels: Set<Int> = []
 
         for program in programs {
-            guard let channelId = resolveChannelId(program: program, tvgIdToChannelId: tvgIdToChannelId) else { continue }
+            guard let channelId = resolveChannelId(program: program, tvgIdToChannelIds: tvgIdToChannelIds, epgDataIdToChannelIds: epgDataIdToChannelIds) else { continue }
             if excludeChannelIds.contains(channelId) || seenChannels.contains(channelId) { continue }
 
             let startDate = formatter.date(from: program.start) ?? fallbackFormatter.date(from: program.start) ?? Date.distantPast
@@ -432,7 +467,7 @@ enum LiveProgramFetcher {
         channelIds: [Int], excludeChannelIds: Set<Int>, limit: Int
     ) async throws -> [TopShelfProgram] {
         let token = try await authenticateDispatcharr(config: config, session: session)
-        let (channels, programs, tvgIdToChannelId) = try await fetchDispatcharrChannelsAndPrograms(config: config, session: session, token: token)
+        let (channels, programs, tvgIdToChannelIds, epgDataIdToChannelIds) = try await fetchDispatcharrChannelsAndPrograms(config: config, session: session, token: token)
 
         let channelMap = Dictionary(uniqueKeysWithValues: channels.map { ($0.id, $0.name) })
 
@@ -445,7 +480,7 @@ enum LiveProgramFetcher {
         var seenChannels: Set<Int> = []
 
         for program in programs {
-            guard let channelId = resolveChannelId(program: program, tvgIdToChannelId: tvgIdToChannelId) else { continue }
+            guard let channelId = resolveChannelId(program: program, tvgIdToChannelIds: tvgIdToChannelIds, epgDataIdToChannelIds: epgDataIdToChannelIds) else { continue }
             guard targetSet.contains(channelId), !seenChannels.contains(channelId) else { continue }
 
             let startDate = formatter.date(from: program.start) ?? fallbackFormatter.date(from: program.start) ?? Date.distantPast

--- a/NexusPVRTests/ProgramTests.swift
+++ b/NexusPVRTests/ProgramTests.swift
@@ -218,4 +218,105 @@ struct ProgramTests {
         #expect(p.id == 7)
         #expect(p.name == "Canonical")
     }
+    // MARK: - Dispatcharr EPG mapping
+
+    @Test("Dispatcharr programs decode epg_data_id as int or string")
+    func dispatcharrProgram_decodesEPGDataId() throws {
+        let intJSON = """
+        {"id":1,"start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T01:00:00Z","title":"Program","epg_data_id":42}
+        """
+        let stringJSON = """
+        {"id":2,"start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T01:00:00Z","title":"Program","epg_data_id":"43"}
+        """
+
+        let intProgram = try JSONDecoder().decode(DispatcharrProgram.self, from: Data(intJSON.utf8))
+        let stringProgram = try JSONDecoder().decode(DispatcharrProgram.self, from: Data(stringJSON.utf8))
+
+        #expect(intProgram.epgDataId == 42)
+        #expect(stringProgram.epgDataId == 43)
+    }
+
+    @Test("Dispatcharr EPG mapper fans dummy epg_data_id programs out to all channels")
+    func dispatcharrMapper_mapsSharedDummyEPGDataIdToAllChannels() throws {
+        let programs = try decodeDispatcharrPrograms("""
+        [
+            {"id":10,"start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T01:00:00Z","title":"Live Event","epg_data_id":9001}
+        ]
+        """)
+
+        let mapped = DispatcharrEPGProgramMapper.map(
+            programs: programs,
+            tvgIdToChannelIds: [:],
+            epgDataIdToChannelIds: [9001: [101, 102]],
+            sortByStart: true
+        )
+
+        #expect(mapped[101]?.map(\.name) == ["Live Event"])
+        #expect(mapped[102]?.map(\.name) == ["Live Event"])
+        #expect(mapped[101]?.first?.channelId == 101)
+        #expect(mapped[102]?.first?.channelId == 102)
+    }
+
+    @Test("Dispatcharr EPG mapper fans shared tvg_id programs out to all channels")
+    func dispatcharrMapper_mapsSharedTVGIdToAllChannels() throws {
+        let programs = try decodeDispatcharrPrograms("""
+        [
+            {"id":11,"start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T01:00:00Z","title":"Shared TVG Event","tvg_id":"dummy-live"}
+        ]
+        """)
+
+        let mapped = DispatcharrEPGProgramMapper.map(
+            programs: programs,
+            tvgIdToChannelIds: ["dummy-live": [201, 202]],
+            epgDataIdToChannelIds: [:],
+            sortByStart: true
+        )
+
+        #expect(mapped[201]?.map(\.name) == ["Shared TVG Event"])
+        #expect(mapped[202]?.map(\.name) == ["Shared TVG Event"])
+    }
+
+    @Test("Dispatcharr EPG mapper resolves dummy grid programs by channel UUID tvg_id")
+    func dispatcharrMapper_mapsChannelUUIDTVGId() throws {
+        let channelUUID = "5214c69b-97e4-4b79-ade1-18b8a5d4923e"
+        let programs = try decodeDispatcharrPrograms("""
+        [
+            {"id":"dummy-custom-596-17","start_time":"2026-06-18T17:00:00+00:00","end_time":"2026-06-18T20:00:00+00:00","title":" Velenje – Rogaska Slatina  - {date} {starttime24}","tvg_id":"\(channelUUID)"}
+        ]
+        """)
+
+        let mapped = DispatcharrEPGProgramMapper.map(
+            programs: programs,
+            tvgIdToChannelIds: [channelUUID: [596]],
+            epgDataIdToChannelIds: [:],
+            sortByStart: true
+        )
+
+        #expect(mapped[596]?.map(\.name) == [" Velenje – Rogaska Slatina  - {date} {starttime24}"])
+        #expect(mapped[596]?.first?.channelId == 596)
+    }
+
+    @Test("Dispatcharr EPG mapper prefers epg_data_id over colliding tvg_id")
+    func dispatcharrMapper_prefersEPGDataIdOverTVGId() throws {
+        let programs = try decodeDispatcharrPrograms("""
+        [
+            {"id":12,"start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T01:00:00Z","title":"Dummy Event","tvg_id":"shared","epg_data_id":77}
+        ]
+        """)
+
+        let mapped = DispatcharrEPGProgramMapper.map(
+            programs: programs,
+            tvgIdToChannelIds: ["shared": [301]],
+            epgDataIdToChannelIds: [77: [302, 303]],
+            sortByStart: true
+        )
+
+        #expect(mapped[301] == nil)
+        #expect(mapped[302]?.map(\.name) == ["Dummy Event"])
+        #expect(mapped[303]?.map(\.name) == ["Dummy Event"])
+    }
+
+    private func decodeDispatcharrPrograms(_ json: String) throws -> [DispatcharrProgram] {
+        try JSONDecoder().decode([DispatcharrProgram].self, from: Data(json.utf8))
+    }
 }


### PR DESCRIPTION
Allow multiple live-event channels to share the same EPG program by mapping both epg_data_id and tvg_id to arrays of channel IDs.