### PR TITLE
Add Channels page with configurable landing tab #100

### DIFF
--- a/NexusPVR/Core/Models/LandingTabOption.swift
+++ b/NexusPVR/Core/Models/LandingTabOption.swift
@@ -1,0 +1,12 @@
+//
+//  LandingTabOption.swift
+//  nextpvr-apple-client
+//
+//  Convenience typealias for the landing tab option enum. The canonical
+//  definition lives inside `UserPreferences` so the tvOS Top Shelf
+//  extension (which only shares `UserPreferences.swift` from the
+//  Core/Models folder) keeps compiling without needing this sibling file
+//  to also be in its membership list.
+//
+
+typealias LandingTabOption = UserPreferences.LandingTabOption

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -23,6 +23,10 @@ nonisolated struct UserPreferences: Codable {
     var guideGroupIds: [Int] = []
     var guideShowProfilesInSidebar: Bool = false
     var guideProfileIds: [Int] = []
+    /// Persisted raw value of the tab the app should open to at launch.
+    /// Stored as a `String` so this model stays free of UI dependencies;
+    /// resolve via the `landingTab` computed property.
+    var landingTabRawValue: String = LandingTabOption.defaultRawValue
     var updatedAt: Date = .distantPast
 
     /// The GPU API for the current platform.
@@ -34,6 +38,38 @@ nonisolated struct UserPreferences: Codable {
         #else
         iosGPUAPI
         #endif
+    }
+
+    /// The tab the app should open to at launch. The raw value is stored on
+    /// disk so this struct doesn't need to import the navigation module.
+    var landingTab: LandingTabOption {
+        get { LandingTabOption(rawValue: landingTabRawValue) ?? .guide }
+        set { landingTabRawValue = newValue.rawValue }
+    }
+
+    /// User-selectable landing page option. Nested inside `UserPreferences`
+    /// (rather than defined as a separate top-level type) so the persistence
+    /// model is self-contained: the tvOS Top Shelf extension shares
+    /// `UserPreferences.swift` but does not include sibling Core/Models
+    /// files. Keeping the enum here means a single source file is enough for
+    /// the Top Shelf to keep compiling.
+    nonisolated enum LandingTabOption: String, CaseIterable, Identifiable, Codable {
+        case guide = "Guide"
+        case channels = "Channels"
+        case completedRecordings = "CompletedRecordings"
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .guide: return "Guide"
+            case .channels: return "Channels"
+            case .completedRecordings: return "Completed Recordings"
+            }
+        }
+
+        /// The raw value used when no preference has been persisted.
+        static var defaultRawValue: String { LandingTabOption.guide.rawValue }
     }
 
     // Migration: keep old property for decoding existing data
@@ -54,6 +90,7 @@ nonisolated struct UserPreferences: Codable {
         case guideGroupIds
         case guideShowProfilesInSidebar
         case guideProfileIds
+        case landingTabRawValue
         case updatedAt
     }
 
@@ -83,6 +120,7 @@ nonisolated struct UserPreferences: Codable {
         guideGroupIds = try container.decodeIfPresent([Int].self, forKey: .guideGroupIds) ?? []
         guideShowProfilesInSidebar = try container.decodeIfPresent(Bool.self, forKey: .guideShowProfilesInSidebar) ?? false
         guideProfileIds = try container.decodeIfPresent([Int].self, forKey: .guideProfileIds) ?? []
+        landingTabRawValue = try container.decodeIfPresent(String.self, forKey: .landingTabRawValue) ?? LandingTabOption.defaultRawValue
         updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? .distantPast
     }
 
@@ -103,6 +141,7 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(guideGroupIds, forKey: .guideGroupIds)
         try container.encode(guideShowProfilesInSidebar, forKey: .guideShowProfilesInSidebar)
         try container.encode(guideProfileIds, forKey: .guideProfileIds)
+        try container.encode(landingTabRawValue, forKey: .landingTabRawValue)
         try container.encode(updatedAt, forKey: .updatedAt)
     }
 

--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -257,6 +257,22 @@ final class EPGCache: ObservableObject {
         return all.filter { $0.endDate > dayStart && $0.startDate < dayEnd }
     }
 
+    /// Returns the program currently airing on the given channel at `date`.
+    /// Returns nil when the channel has no EPG data or no program is airing.
+    /// This is a public helper so views (e.g. Channels grid) can reuse the
+    /// preloaded EPG data without exposing the underlying storage.
+    func currentProgram(forChannelId channelId: Int, at date: Date = Date()) -> Program? {
+        guard let all = epg[channelId] else { return nil }
+        return all.first { program in
+            program.startDate <= date && program.endDate > date
+        }
+    }
+
+    /// Convenience helper that resolves a `Channel` to its current program.
+    func currentProgram(for channel: Channel, at date: Date = Date()) -> Program? {
+        currentProgram(forChannelId: channel.id, at: date)
+    }
+
     // MARK: - Search
 
     func searchPrograms(query: String) async -> [SearchResult] {

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -26,6 +26,16 @@ struct ChannelsView: View {
     #if os(tvOS)
     @FocusState private var focusedChannelId: Int?
     @State private var requestTVSearchKeyboard = false
+    #if DISPATCHERPVR
+    @State private var headerDrawerKind: ChannelsDrawerKind?
+    @FocusState private var focusedDrawerItemId: String?
+    #endif
+    #endif
+
+    #if os(tvOS) && DISPATCHERPVR
+    /// Which header filter is currently expanded as a drawer, matching the
+    /// guide view's group/profile drawer UX.
+    private enum ChannelsDrawerKind { case group, profile }
     #endif
 
     /// Minimum 2 visible columns on iPhone, scales up for iPad / macOS / tvOS.
@@ -115,9 +125,25 @@ struct ChannelsView: View {
             }
             .background(.ultraThinMaterial)
             .onMoveCommand { direction in
+                #if DISPATCHERPVR
+                if headerDrawerKind != nil {
+                    // Up/down navigates the drawer list (handled by the focus
+                    // engine); left/right collapses it, like the guide view.
+                    if direction == .left || direction == .right {
+                        closeDrawer()
+                    }
+                    return
+                }
+                #endif
                 if direction == .left { requestSidebarFocus() }
             }
             .onExitCommand {
+                #if DISPATCHERPVR
+                if headerDrawerKind != nil {
+                    closeDrawer()
+                    return
+                }
+                #endif
                 requestSidebarFocus()
             }
             .task {
@@ -380,12 +406,14 @@ struct ChannelsView: View {
                     tvOSDispatcharrField(
                         icon: "folder.fill",
                         title: "Group",
-                        value: selectedGroupLabel
+                        value: selectedGroupLabel,
+                        kind: .group
                     )
                     tvOSDispatcharrField(
                         icon: "person.fill",
                         title: "Profile",
-                        value: selectedProfileLabel
+                        value: selectedProfileLabel,
+                        kind: .profile
                     )
                 }
                 #endif
@@ -405,8 +433,8 @@ struct ChannelsView: View {
             )
 
             #if DISPATCHERPVR
-            if showFilters && hasFilterData {
-                filterPanel
+            if headerDrawerKind != nil {
+                tvOSHeaderDrawer
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
             #endif
@@ -455,10 +483,12 @@ struct ChannelsView: View {
     }
 
     #if DISPATCHERPVR
-    private func tvOSDispatcharrField(icon: String, title: String, value: String) -> some View {
+    private func tvOSDispatcharrField(icon: String, title: String, value: String, kind: ChannelsDrawerKind) -> some View {
         Button {
-            withAnimation(.easeInOut(duration: Theme.animationDuration)) {
-                showFilters.toggle()
+            if headerDrawerKind == kind {
+                closeDrawer()
+            } else {
+                openDrawer(kind)
             }
         } label: {
             HStack(spacing: 6) {
@@ -473,6 +503,104 @@ struct ChannelsView: View {
         ))
         .focusEffectDisabled()
         .accessibilityLabel("Show \(title.lowercased()) filters")
+    }
+
+    // MARK: - tvOS Group/Profile Drawer (matches guide view UX)
+
+    /// Vertical drawer listing the options for the open filter. Mirrors the
+    /// guide's `tvOSHeaderDrawer`: a titled list with a checkmark on the
+    /// highlighted row. Each row is a focusable button so it works with the
+    /// channels grid's native focus model.
+    private var tvOSHeaderDrawer: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(headerDrawerKind == .group ? "Select Group" : "Select Profile")
+                .font(.headline)
+                .foregroundStyle(Theme.textSecondary)
+
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(currentDrawerItems, id: \.id) { item in
+                        Button {
+                            applyDrawerSelection(item.value)
+                        } label: {
+                            Text(item.label)
+                        }
+                        .buttonStyle(ChannelsDrawerItemButtonStyle())
+                        .focusEffectDisabled()
+                        .focused($focusedDrawerItemId, equals: item.id)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .frame(maxHeight: 360)
+        }
+        .padding(.horizontal, Theme.spacingLG)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.ultraThinMaterial)
+        )
+        .padding(.horizontal, 8)
+        .padding(.bottom, 6)
+        .focusSection()
+    }
+
+    private var currentDrawerItems: [(id: String, label: String, value: Int?)] {
+        switch headerDrawerKind {
+        case .group:
+            return [(id: "group-all", label: "All Groups", value: nil)] +
+                   populatedGroups.map { (id: "group-\($0.id)", label: $0.name, value: $0.id) }
+        case .profile:
+            return [(id: "profile-all", label: "All Profiles", value: nil)] +
+                   epgCache.channelProfiles.map { (id: "profile-\($0.id)", label: $0.name, value: $0.id) }
+        case .none:
+            return []
+        }
+    }
+
+    private var currentDrawerSelectedItemId: String? {
+        let value: Int? = (headerDrawerKind == .group)
+            ? appState.guideGroupFilter
+            : appState.guideProfileFilter
+        return currentDrawerItems.first(where: { $0.value == value })?.id
+    }
+
+    private func openDrawer(_ kind: ChannelsDrawerKind) {
+        withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+            headerDrawerKind = kind
+        }
+        // Defer until the drawer has rendered so the focus lands on the
+        // currently-selected option (like the guide's initial cursor).
+        DispatchQueue.main.async {
+            focusedDrawerItemId = currentDrawerSelectedItemId
+        }
+    }
+
+    private func closeDrawer() {
+        withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+            headerDrawerKind = nil
+        }
+    }
+
+    private func applyDrawerSelection(_ value: Int?) {
+        switch headerDrawerKind {
+        case .group:
+            appState.guideGroupFilter = value
+            if value != nil {
+                appState.guideProfileFilter = nil
+                appState.guideChannelFilter = ""
+            }
+        case .profile:
+            appState.guideProfileFilter = value
+            if value != nil {
+                appState.guideGroupFilter = nil
+                appState.guideChannelFilter = ""
+            }
+        case .none:
+            break
+        }
+        closeDrawer()
     }
     #endif
     #endif
@@ -586,7 +714,7 @@ struct ChannelGridCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacingSM) {
             // Logo header
-            HStack {
+            HStack(alignment: .top) {
                 CachedAsyncImage(url: try? client.channelIconURL(channelId: channel.id)) { image in
                     image
                         .resizable()
@@ -597,6 +725,12 @@ struct ChannelGridCard: View {
                         .foregroundStyle(Theme.textTertiary)
                 }
                 .frame(width: Theme.iconSize, height: Theme.iconSize)
+
+                Spacer(minLength: Theme.spacingSM)
+
+                if let program = currentProgram, let sport = SportDetector.detect(from: program) {
+                    SportIconView(sport: sport, size: Theme.iconSize * 0.5)
+                }
             }
 
             Text(channel.name)
@@ -736,6 +870,49 @@ private struct TVPillFieldFocusWrapper<Content: View>: View {
             .animation(.easeInOut(duration: 0.14), value: isFocused)
     }
 }
+
+#if DISPATCHERPVR
+/// tvOS `ButtonStyle` for rows in the group/profile drawer. Highlighted
+/// (focused) row shows a filled checkmark + accent border, matching the guide
+/// view's `tvOSHeaderDrawer` rows.
+struct ChannelsDrawerItemButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        ChannelsDrawerItemFocusWrapper { configuration.label }
+    }
+}
+
+private struct ChannelsDrawerItemFocusWrapper<Content: View>: View {
+    @Environment(\.isFocused) private var isFocused
+    let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: isFocused ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(isFocused ? Theme.accent : Theme.textTertiary)
+            content()
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .font(.subheadline)
+        .foregroundStyle(isFocused ? Theme.textPrimary : Theme.textSecondary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isFocused ? Theme.surfaceElevated : Theme.surface.opacity(0.3))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(isFocused ? Theme.accent : Theme.surfaceHighlight.opacity(0.5), lineWidth: isFocused ? 2 : 1)
+        )
+        .animation(.easeInOut(duration: 0.12), value: isFocused)
+    }
+}
+#endif
 
 /// Zero-size `UITextField` that only ever drives the on-screen keyboard for the
 /// search field. `canBecomeFocused` is `false` so the focus engine never lands

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -159,12 +159,12 @@ struct ChannelsView: View {
                     self.focusedChannelId = id
                 }
             }
-        #else
+        #elseif os(iOS)
         NavigationStack {
             content
             .navigationTitle("Channels")
             .accessibilityIdentifier("channels-view")
-            #if DISPATCHERPVR && !os(tvOS)
+            #if DISPATCHERPVR
             .toolbar {
                 if hasFilterData {
                     ToolbarItem(placement: .automatic) {
@@ -173,12 +173,8 @@ struct ChannelsView: View {
                 }
             }
             #endif
-            #if os(iOS)
             .searchable(text: $appState.guideChannelFilter, prompt: "Search channels")
             .sidebarMenuToolbar()
-            #elseif os(macOS)
-            .searchable(text: $appState.guideChannelFilter, prompt: "Search channels")
-            #endif
             .alert("Error", isPresented: .constant(streamError != nil)) {
                 Button("OK") { streamError = nil }
             } message: {
@@ -186,6 +182,25 @@ struct ChannelsView: View {
             }
         }
         .background(Theme.background)
+        .task {
+            await tickCurrentTime()
+        }
+        #else
+        // macOS: mirror the guide view — no `.searchable` (its floating field
+        // overlaps the content). A custom nav bar (search + filter toggle) sits
+        // at the top in normal flow, below the title bar. The router gives the
+        // channels tab the same title-bar-respecting inset as the guide.
+        VStack(spacing: 0) {
+            macOSChannelsNavBar
+            content
+                .accessibilityIdentifier("channels-view")
+        }
+        .background(.ultraThinMaterial)
+        .alert("Error", isPresented: .constant(streamError != nil)) {
+            Button("OK") { streamError = nil }
+        } message: {
+            if let error = streamError { Text(error) }
+        }
         .task {
             await tickCurrentTime()
         }
@@ -313,61 +328,79 @@ struct ChannelsView: View {
     }
 
     private var emptyContent: some View {
+        #if os(tvOS)
         VStack(spacing: 0) {
-            #if os(tvOS)
             tvOSFilterBar
-            #else
+            emptyView
+        }
+        #elseif os(macOS)
+        // Filters live in the floating nav bar on macOS.
+        emptyView
+        #else
+        VStack(spacing: 0) {
             #if DISPATCHERPVR
             if showFilters && hasFilterData {
                 filterPanel
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
             #endif
-            #endif
             emptyView
         }
+        #endif
     }
 
     // MARK: - Grid
 
     private var channelGrid: some View {
+        #if os(tvOS)
         VStack(spacing: 0) {
-            #if os(tvOS)
             tvOSFilterBar
-            #else
+            ScrollView {
+                cardsGrid
+            }
+        }
+        #elseif os(macOS)
+        ScrollView {
+            cardsGrid
+        }
+        #else
+        VStack(spacing: 0) {
             #if DISPATCHERPVR
             if showFilters && hasFilterData {
                 filterPanel
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
             #endif
-            #endif
-
             ScrollView {
-                LazyVGrid(columns: columns, spacing: Theme.spacingMD) {
-                    ForEach(visibleChannels) { channel in
-                        Button {
-                            play(channel: channel)
-                        } label: {
-                            ChannelGridCard(
-                                channel: channel,
-                                currentProgram: epgCache.currentProgram(for: channel, at: now)
-                            )
-                        }
-                        .accessibilityIdentifier("channel-card-\(channel.id)")
-                        #if os(tvOS)
-                        .buttonStyle(ChannelGridCardButtonStyle())
-                        .focusEffectDisabled()
-                        .focused($focusedChannelId, equals: channel.id)
-                        .zIndex(focusedChannelId == channel.id ? 1 : 0)
-                        #else
-                        .buttonStyle(.plain)
-                        #endif
-                    }
-                }
-                .padding(Theme.spacingMD)
+                cardsGrid
             }
         }
+        #endif
+    }
+
+    private var cardsGrid: some View {
+        LazyVGrid(columns: columns, spacing: Theme.spacingMD) {
+            ForEach(visibleChannels) { channel in
+                Button {
+                    play(channel: channel)
+                } label: {
+                    ChannelGridCard(
+                        channel: channel,
+                        currentProgram: epgCache.currentProgram(for: channel, at: now)
+                    )
+                }
+                .accessibilityIdentifier("channel-card-\(channel.id)")
+                #if os(tvOS)
+                .buttonStyle(ChannelGridCardButtonStyle())
+                .focusEffectDisabled()
+                .focused($focusedChannelId, equals: channel.id)
+                .zIndex(focusedChannelId == channel.id ? 1 : 0)
+                #else
+                .buttonStyle(.plain)
+                #endif
+            }
+        }
+        .padding(Theme.spacingMD)
     }
 
     private func play(channel: Channel) {
@@ -697,6 +730,74 @@ struct ChannelsView: View {
                 .clipShape(Capsule())
         }
         .buttonStyle(.plain)
+    }
+    #endif
+
+    #if os(macOS)
+    /// macOS nav bar, mirroring the guide's `macOSGuideNavBar`: a capsule search
+    /// field on the left and a filter toggle on the right. Rendered at the top of
+    /// the content in normal flow, below the title bar.
+    private var macOSChannelsNavBar: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: Theme.spacingSM) {
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Theme.textTertiary)
+                    TextField("Search channels", text: $appState.guideChannelFilter)
+                        .textFieldStyle(.plain)
+                        .frame(width: 220)
+                        .accessibilityIdentifier("channels-view-field")
+                    if !appState.guideChannelFilter.isEmpty {
+                        Button {
+                            appState.guideChannelFilter = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(Theme.textTertiary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.ultraThinMaterial)
+                .clipShape(Capsule())
+                .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+
+                Spacer()
+
+                #if DISPATCHERPVR
+                if hasFilterData {
+                    Button {
+                        withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+                            showFilters.toggle()
+                        }
+                    } label: {
+                        Image(systemName: hasActiveFilters
+                              ? "line.3.horizontal.decrease.circle.fill"
+                              : "line.3.horizontal.decrease")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(hasActiveFilters ? Theme.accent : Theme.textPrimary)
+                            .frame(width: 32, height: 32)
+                            .background(.ultraThinMaterial)
+                            .clipShape(Capsule())
+                            .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(showFilters ? "Hide filters" : "Show filters")
+                }
+                #endif
+            }
+            .padding(.horizontal, Theme.spacingMD)
+            .padding(.vertical, Theme.spacingSM)
+
+            #if DISPATCHERPVR
+            if showFilters && hasFilterData {
+                filterPanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            #endif
+        }
     }
     #endif
 }

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -1,0 +1,812 @@
+//
+//  ChannelsView.swift
+//  nextpvr-apple-client
+//
+//  Responsive grid of channels with logo, channel name, and the current
+//  EPG program. Reuses `EPGCache` (no extra network calls, no 50-channel
+//  cap) and the project's `CachedAsyncImage` + Theme constants.
+//
+
+import SwiftUI
+#if os(tvOS)
+import UIKit
+#endif
+
+struct ChannelsView: View {
+    @EnvironmentObject private var client: PVRClient
+    @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var epgCache: EPGCache
+    #if os(tvOS)
+    @Environment(\.requestSidebarFocus) private var requestSidebarFocus
+    #endif
+
+    @State private var streamError: String?
+    @State private var now = Date()
+    @State private var showFilters = false
+    #if os(tvOS)
+    @FocusState private var focusedChannelId: Int?
+    @State private var requestTVSearchKeyboard = false
+    #endif
+
+    /// Minimum 2 visible columns on iPhone, scales up for iPad / macOS / tvOS.
+    private var columns: [GridItem] {
+        #if os(tvOS)
+        return [
+            GridItem(.adaptive(minimum: 320, maximum: 420), spacing: Theme.spacingMD)
+        ]
+        #else
+        return [
+            GridItem(.adaptive(minimum: 160, maximum: 240), spacing: Theme.spacingMD)
+        ]
+        #endif
+    }
+
+    /// Use the full all-channels list rather than `epgCache.visibleChannels`.
+    /// `visibleChannels` is narrowed by guide profile reloads (Dispatcharr
+    /// summary endpoint can return a server-side profile-filtered subset),
+    /// which would make the Channels page mysteriously lose channels when
+    /// the user changes their guide profile. `channels` is the stable,
+    /// unfiltered source.
+    private var visibleChannels: [Channel] {
+        var result = epgCache.channels
+        #if DISPATCHERPVR
+        if let profileId = appState.guideProfileFilter,
+           let profile = epgCache.channelProfiles.first(where: { $0.id == profileId }) {
+            let channelIds = Set(profile.channels)
+            result = result.filter { channelIds.contains($0.id) }
+        } else if let groupId = appState.guideGroupFilter {
+            result = result.filter { $0.groupId == groupId }
+        }
+        #endif
+        guard !appState.guideChannelFilter.isEmpty else { return result }
+        let query = appState.guideChannelFilter.lowercased()
+        return result.filter { channel in
+            channel.name.lowercased().contains(query) ||
+            String(channel.number).contains(query)
+        }
+    }
+
+    #if DISPATCHERPVR
+    private var hasFilterData: Bool {
+        !epgCache.channelProfiles.isEmpty || !populatedGroups.isEmpty
+    }
+
+    private var hasActiveFilters: Bool {
+        appState.guideProfileFilter != nil ||
+        appState.guideGroupFilter != nil ||
+        !appState.guideChannelFilter.isEmpty
+    }
+
+    private var populatedGroups: [ChannelGroup] {
+        epgCache.channelGroups.filter { group in
+            epgCache.channels.contains { $0.groupId == group.id }
+        }
+    }
+
+    private var selectedGroupLabel: String {
+        if let groupId = appState.guideGroupFilter,
+           let group = epgCache.channelGroups.first(where: { $0.id == groupId }) {
+            return group.name
+        }
+        return "All Groups"
+    }
+
+    private var selectedProfileLabel: String {
+        if let profileId = appState.guideProfileFilter,
+           let profile = epgCache.channelProfiles.first(where: { $0.id == profileId }) {
+            return profile.name
+        }
+        return "All Profiles"
+    }
+    #endif
+
+    private var firstVisibleChannelId: Int? {
+        visibleChannels.first?.id
+    }
+
+    var body: some View {
+        #if os(tvOS)
+        content
+            .accessibilityIdentifier("channels-view")
+            .alert("Error", isPresented: .constant(streamError != nil)) {
+                Button("OK") { streamError = nil }
+            } message: {
+                if let error = streamError { Text(error) }
+            }
+            .background(.ultraThinMaterial)
+            .onMoveCommand { direction in
+                if direction == .left { requestSidebarFocus() }
+            }
+            .onExitCommand {
+                requestSidebarFocus()
+            }
+            .task {
+                focusedChannelId = firstVisibleChannelId
+                await tickCurrentTime()
+            }
+            .onChange(of: firstVisibleChannelId) { _, id in
+                guard let focusedChannelId else {
+                    self.focusedChannelId = id
+                    return
+                }
+                if !visibleChannels.contains(where: { $0.id == focusedChannelId }) {
+                    self.focusedChannelId = id
+                }
+            }
+        #else
+        NavigationStack {
+            content
+            .navigationTitle("Channels")
+            .accessibilityIdentifier("channels-view")
+            #if DISPATCHERPVR && !os(tvOS)
+            .toolbar {
+                if hasFilterData {
+                    ToolbarItem(placement: .automatic) {
+                        filterToggleButton
+                    }
+                }
+            }
+            #endif
+            #if os(iOS)
+            .searchable(text: $appState.guideChannelFilter, prompt: "Search channels")
+            .sidebarMenuToolbar()
+            #elseif os(macOS)
+            .searchable(text: $appState.guideChannelFilter, prompt: "Search channels")
+            #endif
+            .alert("Error", isPresented: .constant(streamError != nil)) {
+                Button("OK") { streamError = nil }
+            } message: {
+                if let error = streamError { Text(error) }
+            }
+        }
+        .background(Theme.background)
+        .task {
+            await tickCurrentTime()
+        }
+        #endif
+    }
+
+    private var content: some View {
+        Group {
+            if !epgCache.hasLoaded {
+                loadingView
+            } else if let error = epgCache.error, epgCache.channels.isEmpty {
+                errorView(error)
+            } else if visibleChannels.isEmpty {
+                emptyContent
+            } else {
+                channelGrid
+            }
+        }
+    }
+
+    private func tickCurrentTime() async {
+        // Re-evaluate "current" once a minute so progress bars animate
+        // and programs flip over as the day progresses.
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(60))
+            now = Date()
+        }
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack(spacing: Theme.spacingMD) {
+            ProgressView()
+                .scaleEffect(1.5)
+                .tint(Theme.accent)
+            Text("Loading channels...")
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(_ error: String) -> some View {
+        VStack(spacing: Theme.spacingMD) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.warning)
+            Text("Unable to load channels")
+                .font(.headline)
+                .foregroundStyle(Theme.textPrimary)
+            Text(error)
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// True when the empty state contains its own focusable control (the
+    /// "Clear Filters" button). In that case we must NOT apply
+    /// `tvOSFocusableEmptyState()`, because it wraps the whole empty view in an
+    /// outer focusable `Button` that swallows the inner button's focus — making
+    /// the filter impossible to reset on tvOS.
+    private var emptyStateHasFocusableButton: Bool {
+        #if DISPATCHERPVR
+        return hasActiveFilters
+        #else
+        return false
+        #endif
+    }
+
+    @ViewBuilder
+    private var emptyView: some View {
+        if emptyStateHasFocusableButton {
+            emptyStateBody
+        } else {
+            emptyStateBody
+                .tvOSFocusableEmptyState()
+        }
+    }
+
+    private var emptyStateBody: some View {
+        VStack(spacing: Theme.spacingMD) {
+            Image(systemName: "tv")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.textTertiary)
+            Text(emptyTitle)
+                .font(.headline)
+                .foregroundStyle(Theme.textPrimary)
+            if epgCache.channels.isEmpty {
+                Text(Brand.configureServerMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            #if DISPATCHERPVR
+            if hasActiveFilters {
+                Button("Clear Filters") {
+                    appState.guideChannelFilter = ""
+                    appState.guideGroupFilter = nil
+                    appState.guideProfileFilter = nil
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+            }
+            #endif
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        #if os(tvOS)
+        // Group the empty state as a focus section so the centered "Clear
+        // Filters" button is reachable from the top-left search field — plain
+        // directional focus can't bridge that off-axis jump on tvOS.
+        .focusSection()
+        #endif
+    }
+
+    private var emptyTitle: String {
+        #if DISPATCHERPVR
+        return hasActiveFilters ? "No channels match filters" : "No channels available"
+        #else
+        return appState.guideChannelFilter.isEmpty ? "No channels available" : "No matches"
+        #endif
+    }
+
+    private var emptyContent: some View {
+        VStack(spacing: 0) {
+            #if os(tvOS)
+            tvOSFilterBar
+            #else
+            #if DISPATCHERPVR
+            if showFilters && hasFilterData {
+                filterPanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            #endif
+            #endif
+            emptyView
+        }
+    }
+
+    // MARK: - Grid
+
+    private var channelGrid: some View {
+        VStack(spacing: 0) {
+            #if os(tvOS)
+            tvOSFilterBar
+            #else
+            #if DISPATCHERPVR
+            if showFilters && hasFilterData {
+                filterPanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            #endif
+            #endif
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: Theme.spacingMD) {
+                    ForEach(visibleChannels) { channel in
+                        Button {
+                            play(channel: channel)
+                        } label: {
+                            ChannelGridCard(
+                                channel: channel,
+                                currentProgram: epgCache.currentProgram(for: channel, at: now)
+                            )
+                        }
+                        .accessibilityIdentifier("channel-card-\(channel.id)")
+                        #if os(tvOS)
+                        .buttonStyle(ChannelGridCardButtonStyle())
+                        .focusEffectDisabled()
+                        .focused($focusedChannelId, equals: channel.id)
+                        .zIndex(focusedChannelId == channel.id ? 1 : 0)
+                        #else
+                        .buttonStyle(.plain)
+                        #endif
+                    }
+                }
+                .padding(Theme.spacingMD)
+            }
+        }
+    }
+
+    private func play(channel: Channel) {
+        Task {
+            do {
+                let programName = epgCache.currentProgram(for: channel, at: now)?.name ?? "Live"
+                // Always go through `client.liveStreamURL(channelId:)` —
+                // the raw `channel.streamURL` from the channel summary
+                // response isn't guaranteed to be absolute or to carry a
+                // valid session, so preferring it can produce unplayable
+                // URLs. The PVR client knows the correct base URL, query
+                // parameters, and session for live playback.
+                let url = try await client.liveStreamURL(channelId: channel.id)
+                appState.playStream(
+                    url: url,
+                    title: "\(channel.name) - \(programName)",
+                    channelId: channel.id,
+                    channelName: channel.name
+                )
+            } catch {
+                streamError = error.localizedDescription
+            }
+        }
+    }
+
+    #if os(tvOS)
+    private var tvOSFilterBar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: Theme.spacingLG) {
+                tvOSSearchField
+                #if DISPATCHERPVR
+                if hasFilterData {
+                    Rectangle()
+                        .fill(Theme.surfaceHighlight)
+                        .frame(width: 1, height: 30)
+                    tvOSDispatcharrField(
+                        icon: "folder.fill",
+                        title: "Group",
+                        value: selectedGroupLabel
+                    )
+                    tvOSDispatcharrField(
+                        icon: "person.fill",
+                        title: "Profile",
+                        value: selectedProfileLabel
+                    )
+                }
+                #endif
+
+                Spacer()
+            }
+            .padding(.horizontal, Theme.spacingLG)
+            .frame(minHeight: 62)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Theme.surface.opacity(0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Theme.surfaceHighlight.opacity(0.5), lineWidth: 1)
+            )
+
+            #if DISPATCHERPVR
+            if showFilters && hasFilterData {
+                filterPanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            #endif
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 4)
+        .focusSection()
+    }
+
+    /// The visible search "field" is a focusable `Button` so it picks up the
+    /// guide-style highlight (via `TVPillFieldButtonStyle`) instead of the raw
+    /// system focus halo. Actual text entry is handled by a zero-size,
+    /// non-focusable `UITextField` that becomes first responder (and presents
+    /// the system keyboard) when the button is selected.
+    private var tvOSSearchField: some View {
+        Button {
+            requestTVSearchKeyboard = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                Text(appState.guideChannelFilter.isEmpty ? "Search channels..." : appState.guideChannelFilter)
+                    .lineLimit(1)
+                    .opacity(appState.guideChannelFilter.isEmpty ? 0.6 : 1)
+                Spacer(minLength: 0)
+            }
+            .frame(width: 356, height: 36)
+        }
+        .buttonStyle(TVPillFieldButtonStyle(unfocusedForeground: Theme.textTertiary))
+        .focusEffectDisabled()
+        .accessibilityIdentifier("channels-view-field")
+        .background(
+            ChannelsTVImmediateSearchField(
+                text: $appState.guideChannelFilter,
+                placeholder: "Search channels...",
+                requestFocus: $requestTVSearchKeyboard,
+                onFocusChange: { focused in
+                    if !focused {
+                        requestTVSearchKeyboard = false
+                    }
+                }
+            )
+            .frame(width: 1, height: 1)
+            .opacity(0)
+            .allowsHitTesting(false)
+        )
+    }
+
+    #if DISPATCHERPVR
+    private func tvOSDispatcharrField(icon: String, title: String, value: String) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+                showFilters.toggle()
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                Text("\(title): \(value)")
+                    .lineLimit(1)
+            }
+            .font(.subheadline)
+        }
+        .buttonStyle(TVPillFieldButtonStyle(
+            unfocusedForeground: value.hasPrefix("All ") ? Theme.textTertiary : Theme.accent
+        ))
+        .focusEffectDisabled()
+        .accessibilityLabel("Show \(title.lowercased()) filters")
+    }
+    #endif
+    #endif
+
+    #if DISPATCHERPVR
+    private var filterToggleButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+                showFilters.toggle()
+            }
+        } label: {
+            Image(systemName: hasActiveFilters
+                  ? "line.3.horizontal.decrease.circle.fill"
+                  : "line.3.horizontal.decrease")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(hasActiveFilters ? Theme.accent : Theme.textPrimary)
+                .frame(width: 32, height: 32)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(showFilters ? "Hide filters" : "Show filters")
+    }
+
+    private var filterPanel: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if !epgCache.channelProfiles.isEmpty {
+                filterRow(
+                    label: "Profile",
+                    items: epgCache.channelProfiles.map { (id: $0.id, name: $0.name) },
+                    selectedId: appState.guideProfileFilter
+                ) { id in
+                    appState.guideProfileFilter = id
+                    if id != nil {
+                        appState.guideGroupFilter = nil
+                        appState.guideChannelFilter = ""
+                    }
+                }
+            }
+
+            if !populatedGroups.isEmpty {
+                filterRow(
+                    label: "Group",
+                    items: populatedGroups.map { (id: $0.id, name: $0.name) },
+                    selectedId: appState.guideGroupFilter
+                ) { id in
+                    appState.guideGroupFilter = id
+                    if id != nil {
+                        appState.guideProfileFilter = nil
+                        appState.guideChannelFilter = ""
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, Theme.spacingMD)
+        .padding(.vertical, 4)
+        .background(.ultraThinMaterial)
+    }
+
+    private func filterRow(
+        label: String,
+        items: [(id: Int, name: String)],
+        selectedId: Int?,
+        onSelect: @escaping (Int?) -> Void
+    ) -> some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+                .frame(width: 48, alignment: .leading)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    filterPill("All", isSelected: selectedId == nil) {
+                        onSelect(nil)
+                    }
+                    ForEach(items, id: \.id) { item in
+                        filterPill(item.name, isSelected: selectedId == item.id) {
+                            onSelect(item.id)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(height: 32)
+    }
+
+    private func filterPill(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(isSelected ? .white : Theme.textPrimary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(isSelected ? Theme.accent : Theme.surfaceHighlight)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+    #endif
+}
+
+// MARK: - Channel Grid Card
+
+/// Card view used inside the Channels grid. Mirrors the styling of
+/// `LiveTVView.ChannelCard` but pulls program data from `EPGCache`
+/// (so it never duplicates the per-channel `getListings` request and
+/// is not limited to 50 channels).
+struct ChannelGridCard: View {
+    @EnvironmentObject private var client: PVRClient
+    let channel: Channel
+    let currentProgram: Program?
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.spacingSM) {
+            // Logo header
+            HStack {
+                CachedAsyncImage(url: try? client.channelIconURL(channelId: channel.id)) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } placeholder: {
+                    Image(systemName: "tv")
+                        .font(.title)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+                .frame(width: Theme.iconSize, height: Theme.iconSize)
+            }
+
+            Text(channel.name)
+                .font(.headline)
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+
+            if let program = currentProgram {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(program.cleanName)
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+                        Spacer()
+                        if program.isNew { NewBadge() }
+                    }
+
+                    // Progress bar
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            Rectangle()
+                                .fill(Theme.surfaceHighlight)
+                            Rectangle()
+                                .fill(Theme.accent)
+                                .frame(width: geo.size.width * program.progress())
+                        }
+                    }
+                    .frame(height: 3)
+                    .clipShape(Capsule())
+                }
+            } else {
+                Text("No program info")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textTertiary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(Theme.spacingMD)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: Theme.cornerRadiusMD)
+                .fill(channelInteriorGradient)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMD))
+    }
+
+    private var channelInteriorGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Theme.surfaceElevated,
+                Theme.accent.opacity(0.14),
+                Theme.surface
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
+#Preview {
+    ChannelsView()
+        .environmentObject(PVRClient())
+        .environmentObject(AppState())
+        .environmentObject(EPGCache())
+        .preferredColorScheme(.dark)
+}
+
+#if os(tvOS)
+/// tvOS `ButtonStyle` for the channel grid cards. Draws the same focus
+/// treatment as the guide's program cells (accent border + accent glow +
+/// subtle scale) and — because it is a custom style — fully replaces the
+/// default tvOS button "platter"/glossy focus effect that `.plain` keeps.
+struct ChannelGridCardButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        ChannelGridCardFocusWrapper { configuration.label }
+    }
+}
+
+private struct ChannelGridCardFocusWrapper<Content: View>: View {
+    @Environment(\.isFocused) private var isFocused
+    let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .overlay {
+                RoundedRectangle(cornerRadius: Theme.cornerRadiusMD)
+                    .strokeBorder(isFocused ? Theme.accent.opacity(0.95) : Color.clear, lineWidth: 3)
+            }
+            .shadow(color: isFocused ? Theme.accent.opacity(0.22) : .clear, radius: 10, x: 0, y: 1)
+            .scaleEffect(isFocused ? 1.03 : 1.0)
+            .animation(.easeInOut(duration: 0.14), value: isFocused)
+    }
+}
+
+/// tvOS `ButtonStyle` for the pill-shaped fields in the filter bar (search and
+/// the Dispatcharr group/profile chips). Mirrors the guide's `tvOSSearchField`
+/// / `tvOSDispatcharrField` look: white fill + dark text + scale when focused.
+struct TVPillFieldButtonStyle: ButtonStyle {
+    var unfocusedForeground: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        TVPillFieldFocusWrapper(unfocusedForeground: unfocusedForeground) {
+            configuration.label
+        }
+    }
+}
+
+private struct TVPillFieldFocusWrapper<Content: View>: View {
+    @Environment(\.isFocused) private var isFocused
+    let unfocusedForeground: Color
+    let content: () -> Content
+
+    init(unfocusedForeground: Color, @ViewBuilder content: @escaping () -> Content) {
+        self.unfocusedForeground = unfocusedForeground
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .foregroundStyle(isFocused ? Color(white: 0.1) : unfocusedForeground)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isFocused ? Color.white : Theme.surfaceElevated.opacity(0.75))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isFocused ? Color.clear : Theme.surfaceHighlight, lineWidth: 1)
+            )
+            .scaleEffect(isFocused ? 1.06 : 1.0)
+            .animation(.easeInOut(duration: 0.14), value: isFocused)
+    }
+}
+
+/// Zero-size `UITextField` that only ever drives the on-screen keyboard for the
+/// search field. `canBecomeFocused` is `false` so the focus engine never lands
+/// on it — the visible focusable element is the SwiftUI `Button` in front of it.
+private final class NonFocusableTextField: UITextField {
+    override var canBecomeFocused: Bool { false }
+}
+
+private struct ChannelsTVImmediateSearchField: UIViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+    @Binding var requestFocus: Bool
+    var onFocusChange: (Bool) -> Void
+
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: ChannelsTVImmediateSearchField
+
+        init(parent: ChannelsTVImmediateSearchField) {
+            self.parent = parent
+        }
+
+        @objc func textDidChange(_ sender: UITextField) {
+            parent.text = sender.text ?? ""
+        }
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            parent.onFocusChange(true)
+        }
+
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            parent.onFocusChange(false)
+        }
+
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            textField.resignFirstResponder()
+            return true
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UITextField {
+        let field = NonFocusableTextField(frame: .zero)
+        field.delegate = context.coordinator
+        field.placeholder = placeholder
+        field.text = text
+        field.textColor = UIColor.white
+        field.tintColor = UIColor.white
+        field.borderStyle = .none
+        field.returnKeyType = .search
+        field.addTarget(context.coordinator, action: #selector(Coordinator.textDidChange(_:)), for: .editingChanged)
+        return field
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        context.coordinator.parent = self
+        if uiView.text != text {
+            uiView.text = text
+        }
+        uiView.placeholder = placeholder
+
+        if requestFocus {
+            if !uiView.isFirstResponder {
+                uiView.becomeFirstResponder()
+            }
+        } else if uiView.isFirstResponder {
+            uiView.resignFirstResponder()
+        }
+    }
+}
+
+#endif

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     @State private var subtitleMode: SubtitleMode = UserPreferences.load().subtitleMode
     @State private var subtitleSize: SubtitleSize = UserPreferences.load().subtitleSize
     @State private var subtitleBackground: Bool = UserPreferences.load().subtitleBackground
+    @State private var landingTab: LandingTabOption = UserPreferences.load().landingTab
     #if DISPATCHERPVR
     @State private var guideShowGroupsInSidebar: Bool = UserPreferences.load().guideShowGroupsInSidebar
     @State private var guideGroupIds: [Int] = UserPreferences.load().guideGroupIds
@@ -56,6 +57,7 @@ struct SettingsView: View {
         case subtitleSize
         case subtitleBackground
         case renderer
+        case landingTab
     }
     #endif
 
@@ -66,6 +68,7 @@ struct SettingsView: View {
             #else
             List {
                 serverSection
+                generalSection
                 playbackSection
                 #if DISPATCHERPVR
                 guideSection
@@ -140,6 +143,22 @@ struct SettingsView: View {
                             icon: "network"
                         ) {
                             activeTVPopup = .server
+                        }
+                    }
+                    .focusSection()
+
+                    TVSettingsSection(
+                        title: "General",
+                        icon: "gearshape"
+                    ) {
+                        VStack(spacing: Theme.spacingMD) {
+                            tvSettingsRow(
+                                title: "Landing Page",
+                                value: displayedLandingTab.label,
+                                icon: "house.fill"
+                            ) {
+                                activeTVPopup = .landingTab
+                            }
                         }
                     }
                     .focusSection()
@@ -651,6 +670,8 @@ struct SettingsView: View {
             return "Subtitle Background"
         case .renderer:
             return "Renderer"
+        case .landingTab:
+            return "Landing Page"
         }
     }
 
@@ -771,10 +792,66 @@ struct SettingsView: View {
                     prefs.save()
                 }
             }
+        case .landingTab:
+            return availableLandingOptions
+                .map { option in
+                    TVPopupOption(
+                        id: "settings-popup-landing-\(option.rawValue)",
+                        title: option.label,
+                        isCurrent: displayedLandingTab == option,
+                        isDestructive: false
+                    ) {
+                        saveLandingTab(option)
+                    }
+                }
         }
     }
 
     #endif
+
+    private var generalSection: some View {
+        Section {
+            // Filter the picker to only show landing options the current
+            // user can actually open. Hiding unavailable options keeps the
+            // UI honest and avoids surprising the user with a redirected
+            // landing on next launch.
+            Picker("Landing Page", selection: landingTabSelection) {
+                ForEach(availableLandingOptions) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+            .accessibilityIdentifier("settings-landing-page-picker")
+        } header: {
+            Text("General")
+        } footer: {
+            Text("Choose which page opens when the app launches.")
+        }
+    }
+
+    private var landingTabSelection: Binding<LandingTabOption> {
+        Binding(
+            get: { displayedLandingTab },
+            set: { newValue in saveLandingTab(newValue) }
+        )
+    }
+
+    private var availableLandingOptions: [LandingTabOption] {
+        LandingTabOption.allCases.filter { option in
+            AppState.isLandingOptionAvailable(option, forUserLevel: appState.userLevel)
+        }
+    }
+
+    private var displayedLandingTab: LandingTabOption {
+        availableLandingOptions.contains(landingTab) ? landingTab : .guide
+    }
+
+    private func saveLandingTab(_ option: LandingTabOption) {
+        landingTab = option
+        var prefs = UserPreferences.load()
+        prefs.landingTab = option
+        prefs.save()
+        NotificationCenter.default.post(name: .preferencesDidSync, object: nil)
+    }
 
     private var serverSection: some View {
         Section {

--- a/NexusPVR/Navigation/AppState.swift
+++ b/NexusPVR/Navigation/AppState.swift
@@ -13,7 +13,14 @@ import Combine
 final class AppState: ObservableObject {
     let isUITesting: Bool = ProcessInfo.processInfo.arguments.contains("--ui-testing")
 
-    @Published var selectedTab: Tab = .guide
+    /// Test-only override for the initial landing tab. When set, this takes
+    /// precedence over any persisted `UserPreferences` so tests can be
+    /// deterministic regardless of what's stored on disk or in the iCloud
+    /// KV store. Always nil in production. Mirrors the
+    /// `UserPreferences.demoStore` pattern already used in the codebase.
+    nonisolated(unsafe) static var testLandingTabOverride: LandingTabOption?
+
+    @Published var selectedTab: Tab = AppState.initialLandingTab()
     @Published var searchQuery: String = ""
     @Published var guideChannelFilter: String = ""
     @Published var guideGroupFilter: Int? = nil
@@ -76,7 +83,9 @@ final class AppState: ObservableObject {
     // M3U account error indicator for badge
     @Published var hasM3UErrors = false
     /// User role level from Dispatcharr (0=Streamer, 1=Standard, 10=Admin)
-    @Published var userLevel: Int = 10
+    @Published var userLevel: Int = 10 {
+        didSet { reconcileSelectedTabForCurrentAccess() }
+    }
     #else
     /// NexusPVR users always have full access
     var userLevel: Int { 10 }
@@ -201,6 +210,85 @@ final class AppState: ObservableObject {
         showingRecordingsSeriesList = false
         if userInitiated {
             recordingsFilterUserOverride = true
+        }
+    }
+
+    // MARK: - Landing Tab
+
+    /// Resolve the initial landing tab. Honors `testLandingTabOverride` if
+    /// set (used by tests for deterministic behavior), otherwise falls back
+    /// to the persisted `UserPreferences` value. Unknown / future raw
+    /// values fall back to `.guide` so the app still launches cleanly
+    /// after a downgrade or corrupted preference blob.
+    static func initialLandingTab() -> Tab {
+        if let override = testLandingTabOverride {
+            return tab(for: override)
+        }
+        let prefs = UserPreferences.load()
+        return tab(for: prefs.landingTab)
+    }
+
+    /// Map a `LandingTabOption` to the corresponding `Tab`.
+    /// The mapping is one-way and centralized so that preferences can be
+    /// applied consistently across all platforms and launch paths.
+    static func tab(for option: LandingTabOption) -> Tab {
+        switch option {
+        case .guide: return .guide
+        case .channels: return .channels
+        case .completedRecordings: return .recordings
+        }
+    }
+
+    /// Whether a landing option's target tab is available to the current
+    /// user. The Completed Recordings landing requires `userLevel >= 1`
+    /// (recordings access); the other landings are always available.
+    /// Used by both the Settings picker (to filter out unavailable
+    /// options) and `applyLandingTab` (to redirect to Guide if needed).
+    static func isLandingOptionAvailable(
+        _ option: LandingTabOption,
+        forUserLevel userLevel: Int
+    ) -> Bool {
+        switch option {
+        case .guide, .channels:
+            return true
+        case .completedRecordings:
+            return userLevel >= 1
+        }
+    }
+
+    /// Keep the selected tab in sync with the user's current access level.
+    /// Dispatcharr resolves `userLevel` after launch, so a persisted landing
+    /// tab can briefly select Recordings before the app learns the current
+    /// user is a Streamer. Redirect in that case so the UI never stays on a
+    /// tab that the sidebars have hidden.
+    func reconcileSelectedTabForCurrentAccess() {
+        if selectedTab == .recordings && userLevel < 1 {
+            selectedTab = .guide
+        }
+    }
+
+    /// Convenience helper used by settings UI when applying a new landing
+    /// preference: navigates to the right tab and, for `.completedRecordings`,
+    /// forces the completed filter without setting the user-override flag.
+    /// If the requested option is not available for the current user
+    /// (e.g. Completed Recordings for a Dispatcharr streamer without
+    /// recordings access), falls back to the Guide tab so the user never
+    /// lands on a hidden/non-existent destination.
+    func applyLandingTab(_ option: LandingTabOption) {
+        let resolved: LandingTabOption
+        if Self.isLandingOptionAvailable(option, forUserLevel: userLevel) {
+            resolved = option
+        } else {
+            resolved = .guide
+        }
+        let target = Self.tab(for: resolved)
+        selectedTab = target
+        if resolved == .completedRecordings {
+            recordingsFilter = .completed
+            selectedRecordingsSeriesName = ""
+            showingRecordingsSeriesList = false
+            // The user explicitly chose this landing — do not mark as override.
+            recordingsFilterUserOverride = false
         }
     }
 

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -194,6 +194,8 @@ struct IOSNavigation: View {
                             .toolbarBackground(.visible, for: .navigationBar)
                             .navigationBarTitleDisplayMode(.inline)
                     }
+                case .channels:
+                    ChannelsView()
                 case .topics:
                     if appState.showingKeywordsEditor {
                         NavigationStack {
@@ -1045,6 +1047,8 @@ struct TVOSNavigation: View {
                 switch appState.selectedTab {
                 case .guide:
                     GuideView(onRequestNavBarFocus: { focusSidebar() })
+                case .channels:
+                    ChannelsView()
                 case .recordings:
                     RecordingsListView()
                 case .topics, .calendar:
@@ -1680,6 +1684,8 @@ struct MacOSNavigation: View {
                             switch appState.selectedTab {
                             case .guide:
                                 NavigationStack { GuideView() }
+                            case .channels:
+                                ChannelsView()
                             case .topics:
                                 TopicsView()
                             case .calendar:

--- a/NexusPVR/Navigation/Tab.swift
+++ b/NexusPVR/Navigation/Tab.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-enum Tab: String, Identifiable {
+enum Tab: String, Identifiable, Codable {
     case guide = "Guide"
+    case channels = "Channels"
     case recordings = "Recordings"
     case topics = "Topics"
     case calendar = "Calendar"
@@ -23,6 +24,7 @@ enum Tab: String, Identifiable {
     var icon: String {
         switch self {
         case .guide: return "calendar"
+        case .channels: return "tv"
         case .topics: return "star.fill"
         case .calendar: return "calendar.badge.clock"
         case .search: return "magnifyingglass"
@@ -41,7 +43,7 @@ enum Tab: String, Identifiable {
     }
 
     static func allCases(userLevel: Int) -> [Tab] {
-        var cases: [Tab] = [.guide]
+        var cases: [Tab] = [.guide, .channels]
         if userLevel >= 1 { cases.append(.recordings) }
         cases.append(contentsOf: [.topics, .search])
         #if DISPATCHERPVR
@@ -54,7 +56,7 @@ enum Tab: String, Identifiable {
     #if os(iOS)
     /// Tabs shown in the iOS collapsible nav bar (search is integrated into the bar itself)
     static func iOSTabs(userLevel: Int) -> [Tab] {
-        var cases: [Tab] = [.guide]
+        var cases: [Tab] = [.guide, .channels]
         if userLevel >= 1 { cases.append(.recordings) }
         cases.append(contentsOf: [.topics, .calendar])
         #if DISPATCHERPVR
@@ -68,7 +70,7 @@ enum Tab: String, Identifiable {
     #if os(macOS)
     /// Tabs shown in the macOS sidebar (search is integrated into the guide floating bar)
     static func macOSTabs(userLevel: Int) -> [Tab] {
-        var cases: [Tab] = [.guide]
+        var cases: [Tab] = [.guide, .channels]
         if userLevel >= 1 { cases.append(.recordings) }
         cases.append(contentsOf: [.topics, .calendar])
         #if DISPATCHERPVR
@@ -82,7 +84,7 @@ enum Tab: String, Identifiable {
     #if os(tvOS)
     /// Tabs shown in the tvOS sidebar
     static func tvOSTabs(userLevel: Int) -> [Tab] {
-        var cases: [Tab] = [.guide]
+        var cases: [Tab] = [.guide, .channels]
         if userLevel >= 1 { cases.append(.recordings) }
         cases.append(.topics)
         #if DISPATCHERPVR

--- a/NexusPVRTests/AppStateTests.swift
+++ b/NexusPVRTests/AppStateTests.swift
@@ -15,8 +15,15 @@ struct AppStateTests {
 
     // MARK: - Initial State
 
+    // Note: tests that depend on the initial `selectedTab` set
+    // `testLandingTabOverride` to make the assertion deterministic
+    // regardless of any state persisted in the test process's
+    // UserDefaults / iCloud KV store.
+
     @Test("AppState initial selectedTab is guide")
     func initialSelectedTab() {
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
         let state = AppState()
         #expect(state.selectedTab == .guide)
     }
@@ -255,5 +262,168 @@ struct AppStateTests {
     func recordingsSeriesIsLoadingInitiallyFalse() {
         let state = AppState()
         #expect(state.recordingsSeriesIsLoading == false)
+    }
+
+    // MARK: - Landing tab
+
+    // The landing tab tests use `testLandingTabOverride` so the initial
+    // tab is deterministic regardless of any state that happens to be
+    // persisted in the test process's UserDefaults / iCloud KV store.
+    // Each test sets the override and resets it in a `defer` so leftover
+    // state from a previous test can't leak in.
+
+    @Test("applyLandingTab guide selects the guide tab")
+    func applyLandingTabGuide() {
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.selectedTab = .recordings
+        state.applyLandingTab(.guide)
+        #expect(state.selectedTab == .guide)
+    }
+
+    @Test("applyLandingTab channels selects the channels tab")
+    func applyLandingTabChannels() {
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.selectedTab = .guide
+        state.applyLandingTab(.channels)
+        #expect(state.selectedTab == .channels)
+    }
+
+    @Test("applyLandingTab completedRecordings selects recordings and forces completed filter")
+    func applyLandingTabCompletedRecordings() {
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.selectedTab = .guide
+        state.recordingsFilter = .scheduled
+        state.recordingsFilterUserOverride = true
+        state.selectedRecordingsSeriesName = "Series"
+        state.showingRecordingsSeriesList = true
+
+        state.applyLandingTab(.completedRecordings)
+
+        #expect(state.selectedTab == .recordings)
+        #expect(state.recordingsFilter == .completed)
+        // User override is cleared because this is the app-default landing
+        // behavior, not a manual filter change.
+        #expect(state.recordingsFilterUserOverride == false)
+        #expect(state.selectedRecordingsSeriesName.isEmpty)
+        #expect(state.showingRecordingsSeriesList == false)
+    }
+
+    @Test("applyLandingTab redirects completedRecordings to Guide for userLevel < 1")
+    func applyLandingTabRedirectsWhenUnavailable() {
+        // Dispatcharr userLevel 0 (Streamer) does not have recordings
+        // access, so asking for the Completed Recordings landing must
+        // redirect to the Guide tab instead of silently landing on a
+        // hidden/unavailable destination.
+        #if DISPATCHERPVR
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.userLevel = 0
+        state.selectedTab = .channels
+        // Set a non-default filter so we can prove the redirect leaves
+        // the user's manual selection alone.
+        state.recordingsFilter = .scheduled
+        state.recordingsFilterUserOverride = true
+
+        state.applyLandingTab(.completedRecordings)
+
+        #expect(state.selectedTab == .guide)
+        // The recordings filter must not be touched when we redirect,
+        // so the user's manual filter selection is preserved.
+        #expect(state.recordingsFilter == .scheduled)
+        #expect(state.recordingsFilterUserOverride == true)
+        #endif
+    }
+
+    @Test("applyLandingTab keeps completedRecordings for userLevel >= 1")
+    func applyLandingTabKeepsForAdmin() {
+        #if DISPATCHERPVR
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.userLevel = 10
+        state.selectedTab = .guide
+        // Pre-set a non-default filter and series so the test verifies
+        // that `applyLandingTab(.completedRecordings)` actually resets
+        // those (not just that the tab ends up as `.recordings`).
+        state.recordingsFilter = .scheduled
+        state.recordingsFilterUserOverride = true
+        state.selectedRecordingsSeriesName = "Series"
+        state.showingRecordingsSeriesList = true
+
+        state.applyLandingTab(.completedRecordings)
+
+        #expect(state.selectedTab == .recordings)
+        #expect(state.recordingsFilter == .completed)
+        #expect(state.recordingsFilterUserOverride == false)
+        #expect(state.selectedRecordingsSeriesName.isEmpty)
+        #expect(state.showingRecordingsSeriesList == false)
+        #endif
+    }
+
+    @Test("userLevel downgrade redirects hidden recordings tab to Guide")
+    func userLevelDowngradeRedirectsHiddenRecordingsTab() {
+        #if DISPATCHERPVR
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.userLevel = 10
+        state.selectedTab = .recordings
+
+        state.userLevel = 0
+
+        #expect(state.selectedTab == .guide)
+        #endif
+    }
+
+    @Test("userLevel downgrade leaves available tabs alone")
+    func userLevelDowngradeLeavesAvailableTabsAlone() {
+        #if DISPATCHERPVR
+        AppState.testLandingTabOverride = .guide
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        state.userLevel = 10
+        state.selectedTab = .channels
+
+        state.userLevel = 0
+
+        #expect(state.selectedTab == .channels)
+        #endif
+    }
+
+    @Test("AppState.tab(for:) maps LandingTabOption to the correct Tab")
+    func landingOptionTabMapping() {
+        #expect(AppState.tab(for: .guide) == .guide)
+        #expect(AppState.tab(for: .channels) == .channels)
+        #expect(AppState.tab(for: .completedRecordings) == .recordings)
+    }
+
+    @Test("isLandingOptionAvailable returns true for guide and channels at any level")
+    func isLandingOptionAvailableAlwaysForGuideAndChannels() {
+        for level in [0, 1, 10] {
+            #expect(AppState.isLandingOptionAvailable(.guide, forUserLevel: level) == true)
+            #expect(AppState.isLandingOptionAvailable(.channels, forUserLevel: level) == true)
+        }
+    }
+
+    @Test("isLandingOptionAvailable gates completedRecordings on userLevel >= 1")
+    func isLandingOptionAvailableGatesCompletedRecordings() {
+        #expect(AppState.isLandingOptionAvailable(.completedRecordings, forUserLevel: 0) == false)
+        #expect(AppState.isLandingOptionAvailable(.completedRecordings, forUserLevel: 1) == true)
+        #expect(AppState.isLandingOptionAvailable(.completedRecordings, forUserLevel: 10) == true)
+    }
+
+    @Test("initialLandingTab honors testLandingTabOverride")
+    func initialLandingTabHonorsOverride() {
+        AppState.testLandingTabOverride = .channels
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        #expect(state.selectedTab == .channels)
     }
 }

--- a/NexusPVRTests/EPGCacheTests.swift
+++ b/NexusPVRTests/EPGCacheTests.swift
@@ -154,6 +154,19 @@ struct EPGCacheTests {
         #expect(cache.programs(for: 1, on: Date()).isEmpty)
     }
 
+    @Test("currentProgram returns nil when EPG is not loaded")
+    func currentProgramNotLoaded() {
+        let cache = EPGCache()
+        #expect(cache.currentProgram(forChannelId: 1) == nil)
+        #expect(cache.currentProgram(for: Channel(id: 1, name: "A", number: 1)) == nil)
+    }
+
+    @Test("currentProgram returns nil for unknown channel id")
+    func currentProgramUnknownChannel() {
+        let cache = EPGCache()
+        #expect(cache.currentProgram(forChannelId: 999) == nil)
+    }
+
     // MARK: - Search
 
     @Test("searchProgramsCount returns 0 for empty EPG")

--- a/NexusPVRTests/TabTests.swift
+++ b/NexusPVRTests/TabTests.swift
@@ -15,6 +15,7 @@ struct TabTests {
     @Test("Tab id equals raw value")
     func idEqualsRawValue() {
         #expect(Tab.guide.id == "Guide")
+        #expect(Tab.channels.id == "Channels")
         #expect(Tab.recordings.id == "Recordings")
         #expect(Tab.topics.id == "Topics")
         #expect(Tab.calendar.id == "Calendar")
@@ -25,6 +26,7 @@ struct TabTests {
     @Test("Tab label equals raw value")
     func labelEqualsRawValue() {
         #expect(Tab.guide.label == "Guide")
+        #expect(Tab.channels.label == "Channels")
         #expect(Tab.recordings.label == "Recordings")
         #expect(Tab.settings.label == "Settings")
     }
@@ -32,6 +34,7 @@ struct TabTests {
     @Test("Tab icon returns expected SF Symbol names")
     func iconReturnsExpectedSymbols() {
         #expect(Tab.guide.icon == "calendar")
+        #expect(Tab.channels.icon == "tv")
         #expect(Tab.topics.icon == "star.fill")
         #expect(Tab.calendar.icon == "calendar.badge.clock")
         #expect(Tab.search.icon == "magnifyingglass")
@@ -43,6 +46,7 @@ struct TabTests {
     func allCasesUserLevel0() {
         let cases = Tab.allCases(userLevel: 0)
         #expect(cases.contains(.guide))
+        #expect(cases.contains(.channels))
         #expect(!cases.contains(.recordings))
         #expect(cases.contains(.topics))
         #expect(cases.contains(.search))
@@ -53,6 +57,7 @@ struct TabTests {
     func allCasesUserLevel1() {
         let cases = Tab.allCases(userLevel: 1)
         #expect(cases.contains(.guide))
+        #expect(cases.contains(.channels))
         #expect(cases.contains(.recordings))
         #expect(cases.contains(.topics))
         #expect(cases.contains(.search))
@@ -63,10 +68,22 @@ struct TabTests {
     func allCasesUserLevel10() {
         let cases = Tab.allCases(userLevel: 10)
         #expect(cases.contains(.guide))
+        #expect(cases.contains(.channels))
         #expect(cases.contains(.recordings))
         #expect(cases.contains(.topics))
         #expect(cases.contains(.search))
         #expect(cases.contains(.settings))
+    }
+
+    @Test("Channels tab appears directly below Guide in allCases")
+    func channelsAppearsAfterGuide() {
+        let cases = Tab.allCases(userLevel: 10)
+        guard let guideIndex = cases.firstIndex(of: .guide),
+              let channelsIndex = cases.firstIndex(of: .channels) else {
+            Issue.record("Expected guide and channels to be present in allCases")
+            return
+        }
+        #expect(channelsIndex == guideIndex + 1)
     }
 
     #if os(iOS)
@@ -74,6 +91,7 @@ struct TabTests {
     func iOSTabsUserLevel0() {
         let cases = Tab.iOSTabs(userLevel: 0)
         #expect(cases.contains(.guide))
+        #expect(cases.contains(.channels))
         #expect(!cases.contains(.recordings))
         #expect(cases.contains(.topics))
         #expect(cases.contains(.calendar))
@@ -86,6 +104,17 @@ struct TabTests {
         let cases = Tab.iOSTabs(userLevel: 1)
         #expect(cases.contains(.recordings))
     }
+
+    @Test("Channels tab appears directly below Guide in iOS tabs")
+    func iOSTabsChannelsAfterGuide() {
+        let cases = Tab.iOSTabs(userLevel: 10)
+        guard let guideIndex = cases.firstIndex(of: .guide),
+              let channelsIndex = cases.firstIndex(of: .channels) else {
+            Issue.record("Expected guide and channels to be present in iOS tabs")
+            return
+        }
+        #expect(channelsIndex == guideIndex + 1)
+    }
     #endif
 
     #if os(macOS)
@@ -93,6 +122,7 @@ struct TabTests {
     func macOSTabsUserLevel0() {
         let cases = Tab.macOSTabs(userLevel: 0)
         #expect(cases.contains(.guide))
+        #expect(cases.contains(.channels))
         #expect(!cases.contains(.recordings))
         #expect(cases.contains(.topics))
         #expect(cases.contains(.calendar))
@@ -105,6 +135,17 @@ struct TabTests {
         let cases = Tab.macOSTabs(userLevel: 1)
         #expect(cases.contains(.recordings))
     }
+
+    @Test("Channels tab appears directly below Guide in macOS tabs")
+    func macOSTabsChannelsAfterGuide() {
+        let cases = Tab.macOSTabs(userLevel: 10)
+        guard let guideIndex = cases.firstIndex(of: .guide),
+              let channelsIndex = cases.firstIndex(of: .channels) else {
+            Issue.record("Expected guide and channels to be present in macOS tabs")
+            return
+        }
+        #expect(channelsIndex == guideIndex + 1)
+    }
     #endif
 
     #if os(tvOS)
@@ -112,6 +153,7 @@ struct TabTests {
     func tvOSTabsUserLevel0() {
         let cases = Tab.tvOSTabs(userLevel: 0)
         #expect(cases.contains(.guide))
+        #expect(cases.contains(.channels))
         #expect(!cases.contains(.recordings))
         #expect(cases.contains(.topics))
         #expect(cases.contains(.settings))
@@ -122,6 +164,17 @@ struct TabTests {
     func tvOSTabsUserLevel1() {
         let cases = Tab.tvOSTabs(userLevel: 1)
         #expect(cases.contains(.recordings))
+    }
+
+    @Test("Channels tab appears directly below Guide in tvOS tabs")
+    func tvOSTabsChannelsAfterGuide() {
+        let cases = Tab.tvOSTabs(userLevel: 10)
+        guard let guideIndex = cases.firstIndex(of: .guide),
+              let channelsIndex = cases.firstIndex(of: .channels) else {
+            Issue.record("Expected guide and channels to be present in tvOS tabs")
+            return
+        }
+        #expect(channelsIndex == guideIndex + 1)
     }
     #endif
 }

--- a/NexusPVRTests/UserPreferencesTests.swift
+++ b/NexusPVRTests/UserPreferencesTests.swift
@@ -24,6 +24,7 @@ struct UserPreferencesTests {
         prefs.subtitleSize = .large
         prefs.subtitleBackground = false
         prefs.preferredSubtitleLanguage = "eng"
+        prefs.landingTab = .channels
         prefs.updatedAt = Date(timeIntervalSince1970: 1_700_000_000)
 
         let data = try JSONEncoder().encode(prefs)
@@ -36,6 +37,8 @@ struct UserPreferencesTests {
         #expect(decoded.subtitleSize == prefs.subtitleSize)
         #expect(decoded.subtitleBackground == prefs.subtitleBackground)
         #expect(decoded.preferredSubtitleLanguage == prefs.preferredSubtitleLanguage)
+        #expect(decoded.landingTab == prefs.landingTab)
+        #expect(decoded.landingTabRawValue == prefs.landingTabRawValue)
         #expect(decoded.updatedAt == prefs.updatedAt)
     }
 
@@ -50,7 +53,30 @@ struct UserPreferencesTests {
         #expect(prefs.subtitleSize == .medium)
         #expect(prefs.subtitleBackground == true)
         #expect(prefs.preferredSubtitleLanguage == nil)
+        #expect(prefs.landingTab == .guide)
+        #expect(prefs.landingTabRawValue == LandingTabOption.guide.rawValue)
         #expect(prefs.updatedAt == .distantPast)
+    }
+
+    @Test("Decoding legacy JSON without landingTab defaults to Guide")
+    func decodeLegacyWithoutLandingTab() throws {
+        // Pre-landingTab JSON blobs should still decode cleanly to the
+        // default landing page (Guide) rather than failing.
+        let json = #"{"keywords": ["news"]}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.keywords == ["news"])
+        #expect(prefs.landingTab == .guide)
+    }
+
+    @Test("LandingTabOption round-trips through the raw value")
+    func landingTabRoundTrips() throws {
+        for option in LandingTabOption.allCases {
+            var prefs = UserPreferences()
+            prefs.landingTab = option
+            let data = try JSONEncoder().encode(prefs)
+            let decoded = try JSONDecoder().decode(UserPreferences.self, from: data)
+            #expect(decoded.landingTab == option)
+        }
     }
 
     @Test("Decoding legacy seekTimeSeconds migrates to seekForwardSeconds")


### PR DESCRIPTION
## Summary
- New responsive **Channels** grid (logo, name, current EPG program) backed by `EPGCache` — no extra network calls, no 50-channel cap.
- iOS search + Dispatcharr group/profile filters; live playback via `client.liveStreamURL`.
- tvOS focus reworked to match the Guide: channel cards and filter-bar fields use custom `ButtonStyle`s (`ChannelGridCardButtonStyle`, `TVPillFieldButtonStyle`) with the accent highlight instead of the default system focus effect; search is a focusable button backed by a hidden text field for keyboard entry; empty-state "Clear Filters" reachable via focus sections.
- Configurable **landing tab**: `LandingTabOption` model + wiring through `UserPreferences`, `AppState`, `Tab`, `NavigationRouter`, and Settings.
- Unit tests for `AppState`, `EPGCache`, `Tab`, `UserPreferences`.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
