### PR TITLE
Add user-selectable appearance theme #108

### DIFF
--- a/NexusPVR/AppEntry.swift
+++ b/NexusPVR/AppEntry.swift
@@ -55,6 +55,19 @@ struct PVRApp: App {
                 #if !os(macOS)
                 .ignoresSafeArea()
                 #endif
+                // Appearance override (#108). `nil` follows the device setting.
+                .preferredColorScheme(appState.theme.colorScheme)
+                #if os(macOS)
+                .onAppear { applyAppearance(appState.theme) }
+                .onChange(of: appState.theme) { _, newTheme in applyAppearance(newTheme) }
+                #endif
+                .onReceive(NotificationCenter.default.publisher(for: .preferencesDidSync)) { _ in
+                    // Picks up a theme changed on another device via iCloud.
+                    let theme = UserPreferences.load().theme
+                    if theme != appState.theme {
+                        appState.theme = theme
+                    }
+                }
                 .onReceive(NotificationCenter.default.publisher(for: NSUbiquitousKeyValueStore.didChangeExternallyNotification)) { _ in
                     // Reload server config if it changed from iCloud.
                     // Skip if the user just unlinked — the iCloud removal
@@ -80,6 +93,14 @@ struct PVRApp: App {
         .defaultSize(width: 1200, height: 800)
         #endif
     }
+
+    #if os(macOS)
+    /// Applies the theme to the AppKit layer so the title bar, menus and
+    /// popovers follow the override too (#108).
+    private func applyAppearance(_ theme: AppTheme) {
+        NSApplication.shared.appearance = theme.nsAppearance
+    }
+    #endif
 
     private func validateAuthenticationOnForeground() {
         guard client.isConfigured else { return }

--- a/NexusPVR/Core/Models/AppTheme.swift
+++ b/NexusPVR/Core/Models/AppTheme.swift
@@ -1,0 +1,47 @@
+//
+//  AppTheme.swift
+//  nextpvr-apple-client
+//
+//  Convenience typealias for the appearance override enum (#108). The
+//  canonical definition lives inside `UserPreferences` so the tvOS Top
+//  Shelf extension (which only shares `UserPreferences.swift` from the
+//  Core/Models folder) keeps compiling without needing this sibling file
+//  to also be in its membership list.
+//
+
+import SwiftUI
+
+typealias AppTheme = UserPreferences.AppTheme
+
+extension AppTheme {
+    /// The color scheme to force on the app, or `nil` to follow the device.
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+
+    #if os(macOS)
+    /// The AppKit appearance to force on the app, or `nil` to follow the
+    /// system. Applied alongside `preferredColorScheme` so window chrome and
+    /// menus match the chosen theme, not just the SwiftUI content.
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .system: return nil
+        case .light: return NSAppearance(named: .aqua)
+        case .dark: return NSAppearance(named: .darkAqua)
+        }
+    }
+    #endif
+
+    /// SF Symbol shown next to the option in Settings.
+    var icon: String {
+        switch self {
+        case .system: return "circle.lefthalf.filled"
+        case .light: return "sun.max"
+        case .dark: return "moon"
+        }
+    }
+}

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -29,6 +29,10 @@ nonisolated struct UserPreferences: Codable {
     var landingTabRawValue: String = LandingTabOption.defaultRawValue
     /// When true, all recording features (tabs, menus, buttons) are hidden (#110).
     var hideRecordings: Bool = false
+    /// Persisted raw value of the appearance override (#108). Stored as a
+    /// `String` for the same reason as `landingTabRawValue`: this model stays
+    /// free of UI (SwiftUI) dependencies. Resolve via the `theme` property.
+    var themeRawValue: String = AppTheme.defaultRawValue
     var updatedAt: Date = .distantPast
 
     /// The GPU API for the current platform.
@@ -47,6 +51,35 @@ nonisolated struct UserPreferences: Codable {
     var landingTab: LandingTabOption {
         get { LandingTabOption(rawValue: landingTabRawValue) ?? .guide }
         set { landingTabRawValue = newValue.rawValue }
+    }
+
+    /// The appearance the app should use. The raw value is stored on disk so
+    /// this struct doesn't need to import SwiftUI.
+    var theme: AppTheme {
+        get { AppTheme(rawValue: themeRawValue) ?? .system }
+        set { themeRawValue = newValue.rawValue }
+    }
+
+    /// User-selectable appearance override (#108). Nested here for the same
+    /// reason as `LandingTabOption` — the tvOS Top Shelf extension shares
+    /// `UserPreferences.swift` but not its sibling Core/Models files.
+    nonisolated enum AppTheme: String, CaseIterable, Identifiable, Codable {
+        case system = "System"
+        case light = "Light"
+        case dark = "Dark"
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .system: return "System"
+            case .light: return "Light"
+            case .dark: return "Dark"
+            }
+        }
+
+        /// The raw value used when no preference has been persisted.
+        static var defaultRawValue: String { AppTheme.system.rawValue }
     }
 
     /// User-selectable landing page option. Nested inside `UserPreferences`
@@ -94,6 +127,7 @@ nonisolated struct UserPreferences: Codable {
         case guideProfileIds
         case landingTabRawValue
         case hideRecordings
+        case themeRawValue
         case updatedAt
     }
 
@@ -125,6 +159,7 @@ nonisolated struct UserPreferences: Codable {
         guideProfileIds = try container.decodeIfPresent([Int].self, forKey: .guideProfileIds) ?? []
         landingTabRawValue = try container.decodeIfPresent(String.self, forKey: .landingTabRawValue) ?? LandingTabOption.defaultRawValue
         hideRecordings = try container.decodeIfPresent(Bool.self, forKey: .hideRecordings) ?? false
+        themeRawValue = try container.decodeIfPresent(String.self, forKey: .themeRawValue) ?? AppTheme.defaultRawValue
         updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? .distantPast
     }
 
@@ -147,6 +182,7 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(guideProfileIds, forKey: .guideProfileIds)
         try container.encode(landingTabRawValue, forKey: .landingTabRawValue)
         try container.encode(hideRecordings, forKey: .hideRecordings)
+        try container.encode(themeRawValue, forKey: .themeRawValue)
         try container.encode(updatedAt, forKey: .updatedAt)
     }
 

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -26,6 +26,7 @@ struct SettingsView: View {
     @State private var subtitleBackground: Bool = UserPreferences.load().subtitleBackground
     @State private var landingTab: LandingTabOption = UserPreferences.load().landingTab
     @State private var hideRecordings: Bool = UserPreferences.load().hideRecordings
+    @State private var theme: AppTheme = UserPreferences.load().theme
     #if DISPATCHERPVR
     @State private var guideShowGroupsInSidebar: Bool = UserPreferences.load().guideShowGroupsInSidebar
     @State private var guideGroupIds: [Int] = UserPreferences.load().guideGroupIds
@@ -60,6 +61,7 @@ struct SettingsView: View {
         case renderer
         case landingTab
         case hideRecordings
+        case theme
     }
     #endif
 
@@ -160,6 +162,13 @@ struct SettingsView: View {
                                 icon: "house.fill"
                             ) {
                                 activeTVPopup = .landingTab
+                            }
+                            tvSettingsRow(
+                                title: "Theme",
+                                value: theme.label,
+                                icon: theme.icon
+                            ) {
+                                activeTVPopup = .theme
                             }
                             tvSettingsRow(
                                 title: "Hide Recording Features",
@@ -683,6 +692,8 @@ struct SettingsView: View {
             return "Landing Page"
         case .hideRecordings:
             return "Hide Recording Features"
+        case .theme:
+            return "Theme"
         }
     }
 
@@ -824,6 +835,17 @@ struct SettingsView: View {
                     saveHideRecordings(false)
                 }
             ]
+        case .theme:
+            return AppTheme.allCases.map { option in
+                TVPopupOption(
+                    id: "settings-popup-theme-\(option.rawValue)",
+                    title: option.label,
+                    isCurrent: theme == option,
+                    isDestructive: false
+                ) {
+                    saveTheme(option)
+                }
+            }
         }
     }
 
@@ -842,12 +864,19 @@ struct SettingsView: View {
             }
             .accessibilityIdentifier("settings-landing-page-picker")
 
+            Picker("Theme", selection: themeSelection) {
+                ForEach(AppTheme.allCases) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+            .accessibilityIdentifier("settings-theme-picker")
+
             Toggle("Hide Recording Features", isOn: hideRecordingsSelection)
                 .accessibilityIdentifier("settings-hide-recordings-toggle")
         } header: {
             Text("General")
         } footer: {
-            Text("Choose which page opens when the app launches. Hiding recording features removes all recording menus and buttons from the app.")
+            Text("Choose which page opens when the app launches. Theme overrides the device appearance — System follows your device setting. Hiding recording features removes all recording menus and buttons from the app.")
         }
     }
 
@@ -855,6 +884,13 @@ struct SettingsView: View {
         Binding(
             get: { displayedLandingTab },
             set: { newValue in saveLandingTab(newValue) }
+        )
+    }
+
+    private var themeSelection: Binding<AppTheme> {
+        Binding(
+            get: { theme },
+            set: { newValue in saveTheme(newValue) }
         )
     }
 
@@ -881,6 +917,15 @@ struct SettingsView: View {
         prefs.landingTab = option
         prefs.save()
         NotificationCenter.default.post(name: .preferencesDidSync, object: nil)
+    }
+
+    private func saveTheme(_ option: AppTheme) {
+        theme = option
+        var prefs = UserPreferences.load()
+        prefs.theme = option
+        prefs.save()
+        // Apply immediately so the appearance changes without a relaunch.
+        appState.theme = option
     }
 
     private func saveHideRecordings(_ hidden: Bool) {

--- a/NexusPVR/Navigation/AppState.swift
+++ b/NexusPVR/Navigation/AppState.swift
@@ -99,6 +99,10 @@ final class AppState: ObservableObject {
         didSet { reconcileSelectedTabForCurrentAccess() }
     }
 
+    /// The appearance the user chose in Settings (#108). Applied at the root
+    /// of the scene so a change takes effect immediately, without a relaunch.
+    @Published var theme: AppTheme = UserPreferences.load().theme
+
     /// Whether recording-related UI (tabs, menus, buttons) should be shown.
     var showsRecordings: Bool { userLevel >= 1 && !hideRecordings }
 

--- a/NexusPVRTests/UserPreferencesTests.swift
+++ b/NexusPVRTests/UserPreferencesTests.swift
@@ -26,6 +26,7 @@ struct UserPreferencesTests {
         prefs.preferredSubtitleLanguage = "eng"
         prefs.landingTab = .channels
         prefs.hideRecordings = true
+        prefs.theme = .light
         prefs.updatedAt = Date(timeIntervalSince1970: 1_700_000_000)
 
         let data = try JSONEncoder().encode(prefs)
@@ -41,6 +42,8 @@ struct UserPreferencesTests {
         #expect(decoded.landingTab == prefs.landingTab)
         #expect(decoded.landingTabRawValue == prefs.landingTabRawValue)
         #expect(decoded.hideRecordings == prefs.hideRecordings)
+        #expect(decoded.theme == prefs.theme)
+        #expect(decoded.themeRawValue == prefs.themeRawValue)
         #expect(decoded.updatedAt == prefs.updatedAt)
     }
 
@@ -58,6 +61,8 @@ struct UserPreferencesTests {
         #expect(prefs.landingTab == .guide)
         #expect(prefs.landingTabRawValue == LandingTabOption.guide.rawValue)
         #expect(prefs.hideRecordings == false)
+        #expect(prefs.theme == .system)
+        #expect(prefs.themeRawValue == AppTheme.system.rawValue)
         #expect(prefs.updatedAt == .distantPast)
     }
 
@@ -80,6 +85,32 @@ struct UserPreferencesTests {
             let decoded = try JSONDecoder().decode(UserPreferences.self, from: data)
             #expect(decoded.landingTab == option)
         }
+    }
+
+    @Test("AppTheme round-trips through the raw value")
+    func themeRoundTrips() throws {
+        for option in AppTheme.allCases {
+            var prefs = UserPreferences()
+            prefs.theme = option
+            let data = try JSONEncoder().encode(prefs)
+            let decoded = try JSONDecoder().decode(UserPreferences.self, from: data)
+            #expect(decoded.theme == option)
+            #expect(decoded.themeRawValue == option.rawValue)
+        }
+    }
+
+    @Test("Decoding legacy JSON without a theme defaults to System")
+    func decodeLegacyWithoutTheme() throws {
+        let json = #"{"keywords": ["news"]}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.theme == .system)
+    }
+
+    @Test("An unknown persisted theme falls back to System")
+    func decodeUnknownTheme() throws {
+        let json = #"{"themeRawValue": "Sepia"}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.theme == .system)
     }
 
     @Test("Decoding legacy seekTimeSeconds migrates to seekForwardSeconds")


### PR DESCRIPTION
Add a System/Light/Dark setting to General settings, persisted in UserPreferences and synced via iCloud. The chosen theme applies immediately to SwiftUI content and, on macOS, to the AppKit window chrome.