### PR TITLE
Add user-initiated EPG refresh #118

### DIFF
--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -25,6 +25,9 @@ final class EPGCache: ObservableObject {
     @Published private(set) var isLoading = false
     @Published private(set) var hasLoaded = false
     @Published private(set) var isFullyLoaded = false
+    /// True while a user-initiated refresh is in flight (see `refresh(using:profileId:)`).
+    /// Unlike `isLoading`, the existing data stays on screen while this is true.
+    @Published private(set) var isRefreshing = false
     @Published private(set) var error: String?
 
     private(set) var channelMap: [Int: Channel] = [:]
@@ -113,49 +116,7 @@ final class EPGCache: ObservableObject {
                 print("[EPGCache] Fast EPG failed (\(error.localizedDescription)), falling back to full load")
             }
 
-            backgroundLoadTask = Task { [weak self] in
-                let epgStart = CFAbsoluteTimeGetCurrent()
-                do {
-                    let listings = try await client.getAllListings(for: channelsForEPG)
-                    guard let self, !Task.isCancelled else { return }
-                    defer { self.isLoadInProgress = false }
-                    // Merge into existing fast-window data, deduping per program id.
-                    var merged = self.epg
-                    for (channelId, programs) in listings {
-                        if var existing = merged[channelId], !existing.isEmpty {
-                            let existingIds = Set(existing.map(\.id))
-                            for p in programs where !existingIds.contains(p.id) {
-                                existing.append(p)
-                            }
-                            existing.sort { $0.start < $1.start }
-                            merged[channelId] = existing
-                        } else {
-                            merged[channelId] = programs
-                        }
-                    }
-                    self.epg = merged
-                    // Compute loaded days off main actor
-                    let snapshot = merged
-                    let days = await Task.detached(priority: .utility) {
-                        var daySet = Set<String>()
-                        for programs in snapshot.values {
-                            for program in programs {
-                                daySet.insert(Self.dayFormatter.string(from: program.startDate))
-                            }
-                        }
-                        return daySet
-                    }.value
-                    self.loadedDays = days
-                    let programCount = merged.values.reduce(0) { $0 + $1.count }
-                    self.isFullyLoaded = true
-                    print("[EPGCache] EPG (full): \(programCount) programs across \(merged.count) channels in \(self.ms(since: epgStart))ms")
-                    print("[EPGCache] Total load: \(self.ms(since: totalStart))ms")
-                } catch {
-                    guard !Task.isCancelled else { return }
-                    self?.isLoadInProgress = false
-                    print("[EPGCache] EPG load failed: \(error.localizedDescription)")
-                }
-            }
+            startBackgroundFullLoad(using: client, channels: channelsForEPG, totalStart: totalStart)
 
         } catch {
             self.error = error.localizedDescription
@@ -163,6 +124,129 @@ final class EPGCache: ObservableObject {
             isLoadInProgress = false
             hasLoaded = true
             print("[EPGCache] Load failed after \(ms(since: totalStart))ms: \(error.localizedDescription)")
+        }
+    }
+
+    /// Phase 2 of a load: fetch the full multi-day EPG in the background and merge
+    /// it into whatever the fast window already put in the cache.
+    private func startBackgroundFullLoad(using client: PVRClient, channels channelsForEPG: [Channel], totalStart: CFAbsoluteTime) {
+        isLoadInProgress = true
+        backgroundLoadTask = Task { [weak self] in
+            let epgStart = CFAbsoluteTimeGetCurrent()
+            do {
+                let listings = try await client.getAllListings(for: channelsForEPG)
+                guard let self, !Task.isCancelled else { return }
+                defer { self.isLoadInProgress = false }
+                // Merge into existing fast-window data, deduping per program id.
+                var merged = self.epg
+                for (channelId, programs) in listings {
+                    if var existing = merged[channelId], !existing.isEmpty {
+                        let existingIds = Set(existing.map(\.id))
+                        for p in programs where !existingIds.contains(p.id) {
+                            existing.append(p)
+                        }
+                        existing.sort { $0.start < $1.start }
+                        merged[channelId] = existing
+                    } else {
+                        merged[channelId] = programs
+                    }
+                }
+                self.epg = merged
+                // Compute loaded days off main actor
+                let snapshot = merged
+                let days = await Task.detached(priority: .utility) {
+                    var daySet = Set<String>()
+                    for programs in snapshot.values {
+                        for program in programs {
+                            daySet.insert(Self.dayFormatter.string(from: program.startDate))
+                        }
+                    }
+                    return daySet
+                }.value
+                self.loadedDays = days
+                let programCount = merged.values.reduce(0) { $0 + $1.count }
+                self.isFullyLoaded = true
+                print("[EPGCache] EPG (full): \(programCount) programs across \(merged.count) channels in \(self.ms(since: epgStart))ms")
+                print("[EPGCache] Total load: \(self.ms(since: totalStart))ms")
+            } catch {
+                guard !Task.isCancelled else { return }
+                self?.isLoadInProgress = false
+                print("[EPGCache] EPG load failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// User-initiated refresh (pull-to-refresh on iOS/macOS, refresh button on
+    /// tvOS): re-fetch channels, groups/profiles and EPG from the server so
+    /// server-side changes (a new channel, an updated EPG) show up without
+    /// restarting the app.
+    ///
+    /// Unlike `reloadData`, the currently cached data stays on screen for the
+    /// whole refresh — `hasLoaded`/`isFullyLoaded` are never flipped back to
+    /// false, so the guide doesn't collapse into its loading state and then
+    /// rebuild. New data is swapped in only once it has arrived.
+    func refresh(using client: PVRClient, profileId: Int? = nil) async {
+        guard !isRefreshing else { return }
+        guard client.isConfigured else {
+            error = "Server not configured"
+            return
+        }
+
+        // Drop any in-flight full-EPG load: it would merge stale listings on top
+        // of the data we are about to fetch.
+        backgroundLoadTask?.cancel()
+        backgroundLoadTask = nil
+        isLoadInProgress = false
+
+        isRefreshing = true
+        defer { isRefreshing = false }
+        let totalStart = CFAbsoluteTimeGetCurrent()
+
+        do {
+            if !client.isAuthenticated {
+                try await client.authenticate()
+            }
+
+            #if DISPATCHERPVR
+            let loaded = try await client.getChannelSummary(profileId: profileId)
+            #else
+            let loaded = try await client.getChannels()
+            #endif
+            let sorted = loaded.sorted { $0.number < $1.number }
+
+            #if DISPATCHERPVR
+            let profiles = try? await client.getChannelProfiles()
+            let groups = try? await client.getChannelGroups()
+            #endif
+
+            // Fetch the fast window before publishing anything, so the grid never
+            // shows a channel row without its programs.
+            let fastListings = try? await client.getFastListings(for: sorted)
+
+            channels = sorted
+            if profileId == nil || guideSidebarChannels.isEmpty {
+                guideSidebarChannels = sorted
+            }
+            channelMap = Dictionary(sorted.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+            visibleChannels = sorted
+            #if DISPATCHERPVR
+            if let profiles { channelProfiles = profiles }
+            if let groups { channelGroups = groups }
+            #endif
+            if let fastListings {
+                // Replace rather than merge: programs removed server-side must go.
+                epg = fastListings
+                loadedDays = []
+                markLoadedDays(from: fastListings)
+            }
+            error = nil
+            hasLoaded = true
+            print("[EPGCache] Refresh: \(sorted.count) channels in \(ms(since: totalStart))ms")
+
+            startBackgroundFullLoad(using: client, channels: sorted, totalStart: totalStart)
+        } catch {
+            self.error = error.localizedDescription
+            print("[EPGCache] Refresh failed after \(ms(since: totalStart))ms: \(error.localizedDescription)")
         }
     }
 

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -255,6 +255,15 @@ struct ChannelsView: View {
         }
     }
 
+    /// Re-fetch channels + EPG so channels added server-side appear without
+    /// restarting the app (#118). Refreshes the unfiltered channel list —
+    /// profile/group narrowing stays client-side, as everywhere else on this
+    /// page.
+    private func refreshChannels() async {
+        await epgCache.refresh(using: client)
+        now = Date()
+    }
+
     private func tickCurrentTime() async {
         // Re-evaluate "current" once a minute so progress bars animate
         // and programs flip over as the day progresses.
@@ -408,6 +417,9 @@ struct ChannelsView: View {
             ScrollView {
                 cardsGrid
             }
+            .refreshable {
+                await refreshChannels()
+            }
         }
         #endif
     }
@@ -485,6 +497,8 @@ struct ChannelsView: View {
                 }
                 #endif
 
+                tvOSRefreshButton
+
                 Spacer()
             }
             .padding(.horizontal, Theme.spacingLG)
@@ -509,6 +523,22 @@ struct ChannelsView: View {
         .padding(.horizontal, 4)
         .padding(.vertical, 4)
         .focusSection()
+    }
+
+    /// Reload channels + EPG from the server (#118). tvOS has no pull gesture,
+    /// so the refresh lives in the filter bar next to the search/filter fields.
+    private var tvOSRefreshButton: some View {
+        Button {
+            Task { await refreshChannels() }
+        } label: {
+            Image(systemName: "arrow.clockwise")
+                .font(.system(size: 16, weight: .semibold))
+        }
+        .buttonStyle(TVPillFieldButtonStyle(unfocusedForeground: Theme.textTertiary))
+        .focusEffectDisabled()
+        .disabled(epgCache.isRefreshing)
+        .accessibilityLabel("Refresh channels")
+        .accessibilityIdentifier("channels-refresh-button")
     }
 
     /// The visible search "field" is a focusable `Button` so it picks up the
@@ -799,6 +829,24 @@ struct ChannelsView: View {
                 .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
 
                 Spacer()
+
+                // macOS has no pull-to-refresh gesture, so the page gets an
+                // explicit refresh button next to the filter toggle (#118).
+                Button {
+                    Task { await refreshChannels() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                        .frame(width: 32, height: 32)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Capsule())
+                        .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+                }
+                .buttonStyle(.plain)
+                .disabled(epgCache.isRefreshing)
+                .accessibilityLabel("Refresh channels")
+                .accessibilityIdentifier("channels-refresh-button")
 
                 #if DISPATCHERPVR
                 if hasFilterData {

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -373,6 +373,25 @@ struct GuideView: View {
                 .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
                 Spacer()
 
+                // macOS has no pull-to-refresh gesture, so the guide gets an
+                // explicit refresh button next to the filter toggle (#118).
+                Button {
+                    Task { await refreshGuide() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                        .frame(width: 32, height: 32)
+                        .background(.ultraThinMaterial)
+                        .clipShape(Capsule())
+                        .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+                }
+                .buttonStyle(.plain)
+                .disabled(epgCache.isRefreshing)
+                .accessibilityLabel("Refresh guide")
+                .accessibilityIdentifier("guide-refresh-button")
+                .padding(.trailing, Theme.spacingSM)
+
                 #if DISPATCHERPVR
                 if hasFilterData {
                     Button {
@@ -700,6 +719,9 @@ struct GuideView: View {
                 .modifier(MacScrollDirectionalLockModifier())
                 #endif
             }
+            .refreshable {
+                await refreshGuide()
+            }
             .onScrollGeometryChange(for: CGFloat.self) { geo in
                 geo.containerSize.height
             } action: { _, new in
@@ -780,6 +802,7 @@ struct GuideView: View {
         case group
         case profile
         #endif
+        case refresh
     }
 
     private var tvHeaderItems: [TVGuideHeaderItem] {
@@ -787,6 +810,7 @@ struct GuideView: View {
         #if DISPATCHERPVR
         items.append(contentsOf: [.group, .profile])
         #endif
+        items.append(.refresh)
         return items
     }
 
@@ -1159,6 +1183,15 @@ struct GuideView: View {
                 isFocused: isFocused && focusedItem == .profile
             )
             #endif
+
+            // Reload channels + EPG from the server (#118)
+            tvOSHeaderField(
+                imageName: "arrow.clockwise",
+                isFocused: isFocused && focusedItem == .refresh,
+                isEnabled: !epgCache.isRefreshing
+            )
+            .accessibilityLabel("Refresh guide")
+            .accessibilityIdentifier("guide-refresh-button")
 
             Spacer()
         }
@@ -1536,6 +1569,10 @@ struct GuideView: View {
             endTVSearchEditing()
             openHeaderDrawer(.profile)
         #endif
+        case .refresh:
+            guard !epgCache.isRefreshing else { return }
+            endTVSearchEditing()
+            Task { await refreshGuide() }
         }
     }
 
@@ -1775,6 +1812,14 @@ struct GuideView: View {
         if let targetHour = viewModel.hoursToShow.first(where: { calendar.component(.hour, from: $0) == targetHourComponent }) {
             scrollTargetId = GuideScrollHelper.calculateScrollId(currentTime: targetTime, targetHour: targetHour)
         }
+    }
+
+    /// Pull-to-refresh (iOS/macOS) and the tvOS refresh button both land here:
+    /// re-fetch channels/EPG/recordings so server-side changes show up without
+    /// restarting the app (#118).
+    private func refreshGuide() async {
+        await viewModel.refresh(using: client)
+        viewModel.updateKeywordMatches(keywords: keywords)
     }
 
     private func refreshRecordings() async {

--- a/NexusPVR/Features/Guide/GuideViewModel.swift
+++ b/NexusPVR/Features/Guide/GuideViewModel.swift
@@ -184,6 +184,18 @@ final class GuideViewModel: ObservableObject {
         }
     }
 
+    /// User-initiated refresh of the guide: re-fetch channels + EPG from the
+    /// server (so channels added server-side appear) and reload recordings.
+    /// The grid keeps showing the current data while this runs.
+    func refresh(using client: PVRClient) async {
+        guard let cache = epgCache, client.isConfigured else { return }
+        sportCache = [:]
+        await cache.refresh(using: client, profileId: selectedProfileId)
+        showChannelSearch = cache.channels.count > 25
+        error = cache.error
+        await reloadRecordings(client: client)
+    }
+
     /// Handle date navigation — ensure EPG data is cached for the new date
     func navigateToDate(using client: PVRClient) async {
         guard let cache = epgCache else { return }

--- a/NexusPVRTests/EPGCacheTests.swift
+++ b/NexusPVRTests/EPGCacheTests.swift
@@ -41,6 +41,30 @@ struct EPGCacheTests {
         #expect(cache.isFullyLoaded == false)
     }
 
+    // MARK: - Refresh
+
+    @Test("refresh keeps cached data when the server is not configured")
+    func refreshUnconfiguredKeepsData() async {
+        let cache = EPGCache()
+        cache.channels = makeChannels()
+        cache.visibleChannels = makeChannels()
+
+        await cache.refresh(using: PVRClient(config: ServerConfig(host: "", pin: "", useHTTPS: false)))
+
+        // Unlike reloadData (which invalidates first), refresh must never blank
+        // the grid — the user keeps seeing the channels they had.
+        #expect(cache.channels.count == 3)
+        #expect(cache.visibleChannels.count == 3)
+        #expect(cache.error != nil)
+        #expect(cache.isRefreshing == false)
+    }
+
+    @Test("isRefreshing initially false")
+    func isRefreshingInitiallyFalse() {
+        let cache = EPGCache()
+        #expect(cache.isRefreshing == false)
+    }
+
     // MARK: - Channel Filtering
 
     @Test("filteredChannels returns all when search is empty")

--- a/NexusPVRTests/GuideViewModelTests.swift
+++ b/NexusPVRTests/GuideViewModelTests.swift
@@ -175,6 +175,28 @@ struct GuideViewModelTests {
         #expect(vm.visiblePrograms(for: channel).isEmpty)
     }
 
+    // MARK: - refresh
+
+    @Test("refresh is a no-op when no EPGCache is attached")
+    func refreshWithoutCache() async {
+        let vm = GuideViewModel()
+        await vm.refresh(using: PVRClient(config: ServerConfig(host: "demo", pin: "", useHTTPS: false)))
+        #expect(vm.error == nil)
+        #expect(vm.hasLoaded == false)
+    }
+
+    @Test("refresh keeps cached channels when the server is not configured")
+    func refreshUnconfigured() async {
+        let vm = GuideViewModel()
+        let cache = EPGCache()
+        cache.visibleChannels = [Channel(id: 1, name: "A", number: 1)]
+        vm.epgCache = cache
+
+        await vm.refresh(using: PVRClient(config: ServerConfig(host: "", pin: "", useHTTPS: false)))
+
+        #expect(vm.channels.count == 1)
+    }
+
     // MARK: - updateKeywordMatches
 
     @Test("updateKeywordMatches clears the set when keywords are empty")


### PR DESCRIPTION
Keep cached guide data visible while refreshing so the grid doesn't collapse. Add pull-to-refresh on iOS and refresh buttons on macOS and tvOS. Reload channels, EPG, and recordings so server-side changes appear rwithout restarting the app.