### PR TITLE
Stream switcher in the video information panel #117

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ The project has two schemes:
 - **NextPVR** — StreamClient - For NextPVR
 - **Dispatcharr** — StreamClient
 
-Never build after a change unless explicitly requested.
+Build whenever it's useful to verify a change compiles.
 
 ### Running the App
 

--- a/NexusPVR/Core/Services/DispatcherClient.swift
+++ b/NexusPVR/Core/Services/DispatcherClient.swift
@@ -1733,6 +1733,13 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         return uuidToChannelId[uuid]
     }
 
+    /// Proxy channel UUID for a Dispatcharr channel id, from the map built while
+    /// loading channels. The player knows the channel it started from, but the
+    /// proxy endpoints (`/proxy/ts/status`, `change_stream`) are keyed by UUID.
+    func channelUUID(forId id: Int) -> String? {
+        channelIdToUUID[id]
+    }
+
     /// Switches the source an active channel is streaming from (admin only).
     func switchStream(channelUUID: String, streamId: Int) async throws {
         guard !config.isDemoMode else { return }

--- a/NexusPVR/Features/Player/PlayerStreamSwitcher.swift
+++ b/NexusPVR/Features/Player/PlayerStreamSwitcher.swift
@@ -1,0 +1,153 @@
+//
+//  PlayerStreamSwitcher.swift
+//  DispatcherPVR
+//
+//  Stream selection for the channel playing in the player (#117)
+//
+//  Only the Dispatcharr build shows this (PlayerView gates on DISPATCHERPVR),
+//  but the type stays ungated — like DispatcherClient and ChannelStream — so
+//  the unit test target can exercise it.
+//
+
+import Foundation
+import Combine
+
+/// Backs the stream picker in the player's video information panel.
+///
+/// The stats page has the same picker per active channel (#116); here only the
+/// channel being watched matters, so the state is a single channel's worth.
+@MainActor
+final class PlayerStreamSwitcher: ObservableObject {
+    /// Streams assigned to the playing channel, in the channel's configured order.
+    @Published private(set) var streams: [ChannelStream] = []
+    /// Stream the proxy reports the channel is playing.
+    @Published private(set) var reportedStreamId: Int?
+    @Published private(set) var isSwitching = false
+    @Published private(set) var errorMessage: String?
+
+    private(set) var channelUUID: String?
+    private var accountNames: [Int: String] = [:]
+    private var loadedChannelId: Int?
+
+    /// Locally selected stream id, kept until the server reports the switch.
+    /// The proxy needs a few seconds to restart the source, so without this the
+    /// picker would snap back to the previous stream right after a selection.
+    private var pendingSelection: Int?
+    private var pendingSelectionAt: Date?
+    /// How long a local selection wins over the server's reported stream before
+    /// it's dropped, so a failed switch can't pin the picker to the wrong stream.
+    private let pendingSelectionTimeout: TimeInterval = 20
+    private let now: () -> Date
+
+    init(now: @escaping () -> Date = Date.init) {
+        self.now = now
+    }
+
+    /// The stream to show as selected — the pending local selection while a
+    /// switch is settling, otherwise whatever the server reports.
+    var activeStreamId: Int? { pendingSelection ?? reportedStreamId }
+
+    /// Switching is an admin action on the Dispatcharr REST/proxy API, so the
+    /// picker is hidden for read-only and output-only (Streamer) users.
+    static func canSwitchStreams(client: DispatcherClient, appState: AppState) -> Bool {
+        appState.userLevel >= 10 && !client.useOutputEndpoints && !client.config.isDemoMode
+    }
+
+    func label(for stream: ChannelStream) -> String {
+        stream.label(accountNameLookup: { [accountNames] id in accountNames[id] })
+    }
+
+    // MARK: - Loading
+
+    /// Loads the streams assigned to the playing channel. Reloads only when the
+    /// channel changes, so the player's status polling can call it freely.
+    func load(channelId: Int?, client: DispatcherClient) async {
+        guard let channelId else {
+            reset()
+            return
+        }
+        guard loadedChannelId != channelId else { return }
+
+        reset()
+        loadedChannelId = channelId
+        channelUUID = client.channelUUID(forId: channelId)
+
+        do {
+            let loaded = try await client.getChannelStreams(channelId: channelId)
+            // A channel switch mid-load would make this stale.
+            guard loadedChannelId == channelId else { return }
+            streams = loaded
+        } catch {
+            // Allow a retry on the next channel change / panel open.
+            loadedChannelId = nil
+            return
+        }
+
+        if let accounts = try? await client.getM3UAccounts(), loadedChannelId == channelId {
+            accountNames = Dictionary(accounts.map { ($0.id, $0.name) }, uniquingKeysWith: { first, _ in first })
+        }
+    }
+
+    /// Picks the playing channel out of a `/proxy/ts/status` response and takes
+    /// the stream it reports. Channels missing from the response (they drop out
+    /// briefly while a switch restarts the source) leave the state untouched.
+    func applyStatus(_ channels: [ProxyChannelStatus]) {
+        guard let channelUUID else { return }
+        guard let match = channels.first(where: { $0.channelId == channelUUID }) else { return }
+        reportedStreamId = match.streamId
+        clearPendingSelectionIfSettled(reported: match.streamId)
+    }
+
+    func reset() {
+        streams = []
+        reportedStreamId = nil
+        errorMessage = nil
+        channelUUID = nil
+        accountNames = [:]
+        loadedChannelId = nil
+        pendingSelection = nil
+        pendingSelectionAt = nil
+    }
+
+    // MARK: - Switching
+
+    func select(_ stream: ChannelStream, client: DispatcherClient) async {
+        guard let channelUUID, !isSwitching else { return }
+
+        errorMessage = nil
+        isSwitching = true
+        defer { isSwitching = false }
+
+        do {
+            try await client.switchStream(channelUUID: channelUUID, streamId: stream.id)
+            pendingSelection = stream.id
+            pendingSelectionAt = now()
+        } catch {
+            errorMessage = "Could not switch to \(stream.displayName): \(error.localizedDescription)"
+        }
+    }
+
+    private func clearPendingSelectionIfSettled(reported: Int?) {
+        guard let pending = pendingSelection else { return }
+        let expired = now().timeIntervalSince(pendingSelectionAt ?? now()) > pendingSelectionTimeout
+        if reported == pending || expired {
+            pendingSelection = nil
+            pendingSelectionAt = nil
+        }
+    }
+
+    #if DEBUG
+    /// Test seam: puts the switcher in the state `load(channelId:client:)` would.
+    func prepareForTesting(channelUUID: String, streams: [ChannelStream], accountNames: [Int: String] = [:]) {
+        self.channelUUID = channelUUID
+        self.streams = streams
+        self.accountNames = accountNames
+    }
+
+    /// Test seam: records a selection as if the switch request had succeeded.
+    func markPendingSelectionForTesting(_ streamId: Int, at date: Date) {
+        pendingSelection = streamId
+        pendingSelectionAt = date
+    }
+    #endif
+}

--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -98,6 +98,7 @@ struct PlayerView: View {
     #if DISPATCHERPVR
     @State private var dispatchProfileBadge: String?
     @State private var dispatchProfileRefreshTask: Task<Void, Never>?
+    @StateObject private var streamSwitcher = PlayerStreamSwitcher()
     #endif
     #if os(tvOS)
     @State private var hasSetDisplayCriteria = false
@@ -1363,9 +1364,20 @@ struct PlayerView: View {
         !isLiveStream && !isRecordingInProgress && duration > 0
     }
 
+    /// Rows the video tab offers to the remote: chapters for recordings, and the
+    /// stream picker for a live channel (#117). The two never coexist — chapters
+    /// need a seekable recording, streams a live proxy channel.
+    private var tvVideoTabRowCount: Int {
+        if hasChapters { return 10 }
+        #if DISPATCHERPVR
+        if canSwitchDispatchStreams { return streamSwitcher.streams.count }
+        #endif
+        return 0
+    }
+
     private var tvTrackCount: Int {
         switch settingsTab {
-        case .video: return hasChapters ? 10 : 0
+        case .video: return tvVideoTabRowCount
         case .audio: return trackList.filter { $0.type == "audio" }.count
         case .subtitles: return trackList.filter { $0.type == "sub" }.count + 1 // +1 for "None"
         }
@@ -1375,10 +1387,18 @@ struct PlayerView: View {
         guard tvFocusedTrackIndex >= 0 else { return }
         switch settingsTab {
         case .video:
-            if hasChapters && tvFocusedTrackIndex < 10 {
-                let chapterPosition = duration / 10.0 * Double(tvFocusedTrackIndex)
-                seekToPosition(chapterPosition)
+            if hasChapters {
+                if tvFocusedTrackIndex < 10 {
+                    let chapterPosition = duration / 10.0 * Double(tvFocusedTrackIndex)
+                    seekToPosition(chapterPosition)
+                }
+                return
             }
+            #if DISPATCHERPVR
+            if canSwitchDispatchStreams, tvFocusedTrackIndex < streamSwitcher.streams.count {
+                selectDispatchStream(streamSwitcher.streams[tvFocusedTrackIndex])
+            }
+            #endif
         case .audio:
             let audioTracks = trackList.filter { $0.type == "audio" }
             if tvFocusedTrackIndex < audioTracks.count {
@@ -1532,6 +1552,10 @@ struct PlayerView: View {
             if droppedFrames > 0 {
                 videoInfoRow("Dropped", "\(droppedFrames)")
             }
+
+            #if DISPATCHERPVR
+            dispatchStreamSection
+            #endif
 
             if !isLiveStream && !isRecordingInProgress && duration > 0 {
                 Divider()
@@ -1771,6 +1795,73 @@ struct PlayerView: View {
     }
 
     #if DISPATCHERPVR
+    /// Stream picker for the playing channel, inside the video information
+    /// panel (#117) — the same switch the stats page offers per channel (#116).
+    @ViewBuilder
+    private var dispatchStreamSection: some View {
+        if canSwitchDispatchStreams && !streamSwitcher.streams.isEmpty {
+            Divider()
+                .background(.gray.opacity(0.5))
+                .padding(.vertical, Theme.spacingSM)
+
+            HStack(spacing: Theme.spacingSM) {
+                Text("Streams")
+                    .font(panelLabelFont)
+                    .foregroundStyle(.gray)
+                if streamSwitcher.isSwitching {
+                    #if os(tvOS)
+                    ProgressView()
+                    #else
+                    ProgressView()
+                        .controlSize(.small)
+                    #endif
+                }
+            }
+            .padding(.bottom, 4)
+
+            ForEach(Array(streamSwitcher.streams.enumerated()), id: \.element.id) { index, stream in
+                dispatchStreamRow(stream, index: index)
+            }
+
+            if let message = streamSwitcher.errorMessage {
+                Text(message)
+                    .font(panelLabelFont)
+                    .foregroundStyle(Theme.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, Theme.spacingMD)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private func dispatchStreamRow(_ stream: ChannelStream, index: Int) -> some View {
+        let isActive = stream.id == streamSwitcher.activeStreamId
+        return Button {
+            selectDispatchStream(stream)
+        } label: {
+            HStack {
+                Text(streamSwitcher.label(for: stream))
+                    .font(panelTextFont)
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: Theme.spacingSM)
+                if isActive {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .padding(.horizontal, Theme.spacingMD)
+            .padding(.vertical, 10)
+            .background(tvOSFocused(index) ? Color.white.opacity(0.2) : Color.clear)
+            .cornerRadius(6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(streamSwitcher.isSwitching)
+        .accessibilityIdentifier("player-stream-row")
+    }
+
     private var canQueryDispatchProxyStatus: Bool {
         // Streamer/output-only users don't have access to /proxy/ts/status.
         appState.userLevel >= 1 && !client.useOutputEndpoints
@@ -1784,11 +1875,36 @@ struct PlayerView: View {
             return
         }
         dispatchProfileRefreshTask = Task {
+            // Load the channel's streams first so the status polls below can
+            // report which one is playing (#117).
+            await loadDispatchStreams()
             await refreshDispatchProfileBadge()
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(8))
                 await refreshDispatchProfileBadge()
             }
+        }
+    }
+
+    /// Stream switching is an admin action, and only applies to a live channel
+    /// going through the proxy — recordings are plain files.
+    private var canSwitchDispatchStreams: Bool {
+        isLiveStream && PlayerStreamSwitcher.canSwitchStreams(client: client, appState: appState)
+    }
+
+    private func loadDispatchStreams() async {
+        guard canSwitchDispatchStreams else {
+            streamSwitcher.reset()
+            return
+        }
+        await streamSwitcher.load(channelId: appState.currentlyPlayingChannelId, client: client)
+    }
+
+    private func selectDispatchStream(_ stream: ChannelStream) {
+        Task {
+            await streamSwitcher.select(stream, client: client)
+            // Reflect the new source (and its profile) as soon as the proxy settles.
+            await refreshDispatchProfileBadge()
         }
     }
 
@@ -1814,6 +1930,7 @@ struct PlayerView: View {
         do {
             let status = try await client.getProxyStatus()
             guard let channels = status.channels, !channels.isEmpty else { return nil }
+            streamSwitcher.applyStatus(channels)
 
             // Prefer active channels only when available.
             let activeChannels = channels.filter { $0.state.lowercased() == "active" }

--- a/NexusPVRTests/PlayerStreamSwitcherTests.swift
+++ b/NexusPVRTests/PlayerStreamSwitcherTests.swift
@@ -1,0 +1,122 @@
+//
+//  PlayerStreamSwitcherTests.swift
+//  NexusPVRTests
+//
+//  Tests for the player's stream picker state (#117).
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+@MainActor
+struct PlayerStreamSwitcherTests {
+
+    private func status(channelId: String, streamId: Int?) throws -> ProxyChannelStatus {
+        let stream = streamId.map { "\($0)" } ?? "null"
+        let json = #"""
+        {"channel_id": "\#(channelId)", "channel_name": "TSN 1", "stream_id": \#(stream), "state": "active"}
+        """#
+        return try JSONDecoder().decode(ProxyChannelStatus.self, from: Data(json.utf8))
+    }
+
+    private func stream(_ id: Int, name: String, account: Int? = nil) -> ChannelStream {
+        ChannelStream(id: id, name: name, m3uAccountId: account)
+    }
+
+    // MARK: - Reading the proxy status
+
+    @Test("Takes the active stream from the playing channel's status entry")
+    func readsActiveStream() throws {
+        let switcher = PlayerStreamSwitcher()
+        switcher.prepareForTesting(channelUUID: "uuid-1", streams: [stream(1, name: "A"), stream(2, name: "B")])
+
+        try switcher.applyStatus([
+            status(channelId: "uuid-other", streamId: 9),
+            status(channelId: "uuid-1", streamId: 2)
+        ])
+
+        #expect(switcher.activeStreamId == 2)
+    }
+
+    @Test("Ignores a status response that doesn't include the playing channel")
+    func ignoresUnrelatedStatus() throws {
+        let switcher = PlayerStreamSwitcher()
+        switcher.prepareForTesting(channelUUID: "uuid-1", streams: [stream(1, name: "A")])
+        try switcher.applyStatus([status(channelId: "uuid-1", streamId: 1)])
+
+        // The channel drops out of the status while the proxy restarts a source.
+        try switcher.applyStatus([status(channelId: "uuid-other", streamId: 7)])
+
+        #expect(switcher.activeStreamId == 1)
+    }
+
+    @Test("Reports no active stream before any status arrives")
+    func noActiveStreamInitially() {
+        let switcher = PlayerStreamSwitcher()
+        switcher.prepareForTesting(channelUUID: "uuid-1", streams: [stream(1, name: "A")])
+
+        #expect(switcher.activeStreamId == nil)
+    }
+
+    // MARK: - Pending selections
+
+    @Test("A pending selection wins until the server reports it")
+    func pendingSelectionWins() throws {
+        let switcher = PlayerStreamSwitcher()
+        switcher.prepareForTesting(channelUUID: "uuid-1", streams: [stream(1, name: "A"), stream(2, name: "B")])
+        switcher.markPendingSelectionForTesting(2, at: Date())
+
+        // Proxy still on the old source right after the switch.
+        try switcher.applyStatus([status(channelId: "uuid-1", streamId: 1)])
+        #expect(switcher.activeStreamId == 2)
+
+        try switcher.applyStatus([status(channelId: "uuid-1", streamId: 2)])
+        #expect(switcher.activeStreamId == 2)
+        #expect(switcher.reportedStreamId == 2)
+    }
+
+    @Test("A pending selection that never lands expires")
+    func pendingSelectionExpires() throws {
+        let now = Date()
+        let switcher = PlayerStreamSwitcher(now: { now })
+        switcher.prepareForTesting(channelUUID: "uuid-1", streams: [stream(1, name: "A"), stream(2, name: "B")])
+        // Selected well past the 20s timeout — a failed switch must not pin the
+        // picker to a stream the server isn't playing.
+        switcher.markPendingSelectionForTesting(2, at: now.addingTimeInterval(-60))
+
+        try switcher.applyStatus([status(channelId: "uuid-1", streamId: 1)])
+
+        #expect(switcher.activeStreamId == 1)
+    }
+
+    // MARK: - Labels
+
+    @Test("Labels streams with their M3U account name")
+    func labelsStreams() {
+        let switcher = PlayerStreamSwitcher()
+        switcher.prepareForTesting(
+            channelUUID: "uuid-1",
+            streams: [stream(1, name: "TSN 1 FHD", account: 3), stream(2, name: "Backup")],
+            accountNames: [3: "Provider A"]
+        )
+
+        #expect(switcher.label(for: switcher.streams[0]) == "TSN 1 FHD [Provider A]")
+        #expect(switcher.label(for: switcher.streams[1]) == "Backup")
+    }
+
+    // MARK: - Reset
+
+    @Test("Reset clears the channel's state")
+    func resetClearsState() throws {
+        let switcher = PlayerStreamSwitcher()
+        switcher.prepareForTesting(channelUUID: "uuid-1", streams: [stream(1, name: "A")])
+        try switcher.applyStatus([status(channelId: "uuid-1", streamId: 1)])
+
+        switcher.reset()
+
+        #expect(switcher.streams.isEmpty)
+        #expect(switcher.activeStreamId == nil)
+        #expect(switcher.channelUUID == nil)
+    }
+}


### PR DESCRIPTION
Closes #117. Follow-up to #116 — the stream (source) picker the stats page shows per active channel is now available while a channel is playing, in the **Video** tab of the player's stream settings panel.

## What changed

- **`PlayerStreamSwitcher`** (new, `Features/Player/`) — holds the playing channel's streams, the source `/proxy/ts/status` reports, and a short-lived pending selection so the picker doesn't snap back to the old source while the proxy restarts the stream (same 20s settle rule as the stats page).
- **`PlayerView`** — renders the picker in `videoTabContent`, reusing the existing `/proxy/ts/status` poll (every 8s, already there for the profile badge) to track the active stream. Shown only for live playback with admin access (`userLevel >= 10`, not output-only, not demo).
- **tvOS** — remote focus in the Video tab now walks the stream rows. Chapters and streams never coexist (chapters need a seekable recording, streams a live proxy channel), so they share the index space.
- **`DispatcherClient.channelUUID(forId:)`** — the id → UUID direction; the player knows the channel id it started from, while `change_stream` / `status` are keyed by UUID.
- **Tests** — `PlayerStreamSwitcherTests` covers status matching, pending-selection precedence and expiry, labelling, and reset.
- Also drops the "never build after a change" rule from `CLAUDE.md` (separate commit).

## Verification

| Check | Result |
| --- | --- |
| Dispatcharr — iOS / tvOS / macOS build | ✅ |
| NextPVR — iOS build | ✅ |
| `NexusPVRTests` (both schemes, iOS sim) | ✅ 624 tests, 50 suites |

Not yet exercised against a real Dispatcharr server — the mock server already serves the `#116` endpoints.

## Note

Switching does not reload the player: the proxy keeps the client connection and swaps the source behind it, matching the web app's behaviour. Worth confirming on a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)