### PR TITLE
Add Dispatcharr stats landing option gating

### DIFF
--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -96,6 +96,9 @@ nonisolated struct UserPreferences: Codable {
         case guide = "Guide"
         case channels = "Channels"
         case completedRecordings = "CompletedRecordings"
+        #if DISPATCHERPVR
+        case stats = "Stats"
+        #endif
 
         var id: String { rawValue }
 
@@ -104,6 +107,9 @@ nonisolated struct UserPreferences: Codable {
             case .guide: return "Guide"
             case .channels: return "Channels"
             case .completedRecordings: return "Completed Recordings"
+            #if DISPATCHERPVR
+            case .stats: return "Status"
+            #endif
             }
         }
 

--- a/NexusPVR/Navigation/AppState.swift
+++ b/NexusPVR/Navigation/AppState.swift
@@ -379,12 +379,16 @@ final class AppState: ObservableObject {
         case .guide: return .guide
         case .channels: return .channels
         case .completedRecordings: return .recordings
+        #if DISPATCHERPVR
+        case .stats: return .stats
+        #endif
         }
     }
 
     /// Whether a landing option's target tab is available to the current
     /// user. The Completed Recordings landing requires `userLevel >= 1`
-    /// (recordings access); the other landings are always available.
+    /// (recordings access) and the Status landing (Dispatcharr only)
+    /// requires `userLevel >= 1`; the other landings are always available.
     /// Used by both the Settings picker (to filter out unavailable
     /// options) and `applyLandingTab` (to redirect to Guide if needed).
     static func isLandingOptionAvailable(
@@ -397,6 +401,10 @@ final class AppState: ObservableObject {
             return true
         case .completedRecordings:
             return userLevel >= 1 && !hideRecordings
+        #if DISPATCHERPVR
+        case .stats:
+            return userLevel >= 1
+        #endif
         }
     }
 
@@ -409,6 +417,11 @@ final class AppState: ObservableObject {
         if selectedTab == .recordings && !showsRecordings {
             selectedTab = .guide
         }
+        #if DISPATCHERPVR
+        if selectedTab == .stats && userLevel < 1 {
+            selectedTab = .guide
+        }
+        #endif
     }
 
     /// Convenience helper used by settings UI when applying a new landing

--- a/NexusPVRTests/AppStateTests.swift
+++ b/NexusPVRTests/AppStateTests.swift
@@ -402,6 +402,9 @@ struct AppStateTests {
         #expect(AppState.tab(for: .guide) == .guide)
         #expect(AppState.tab(for: .channels) == .channels)
         #expect(AppState.tab(for: .completedRecordings) == .recordings)
+        #if DISPATCHERPVR
+        #expect(AppState.tab(for: .stats) == .stats)
+        #endif
     }
 
     @Test("isLandingOptionAvailable returns true for guide and channels at any level")
@@ -418,6 +421,27 @@ struct AppStateTests {
         #expect(AppState.isLandingOptionAvailable(.completedRecordings, forUserLevel: 1) == true)
         #expect(AppState.isLandingOptionAvailable(.completedRecordings, forUserLevel: 10) == true)
     }
+
+    #if DISPATCHERPVR
+    @Test("isLandingOptionAvailable gates stats on userLevel >= 1")
+    func isLandingOptionAvailableGatesStats() {
+        #expect(AppState.isLandingOptionAvailable(.stats, forUserLevel: 0) == false)
+        #expect(AppState.isLandingOptionAvailable(.stats, forUserLevel: 1) == true)
+        #expect(AppState.isLandingOptionAvailable(.stats, forUserLevel: 10) == true)
+        // Hiding recording features must not hide the Status landing.
+        #expect(AppState.isLandingOptionAvailable(.stats, forUserLevel: 1, hideRecordings: true) == true)
+    }
+
+    @Test("Stats landing is redirected to Guide for streamer-level users")
+    func statsLandingRedirectsForStreamers() {
+        AppState.testLandingTabOverride = .stats
+        defer { AppState.testLandingTabOverride = nil }
+        let state = AppState()
+        #expect(state.selectedTab == .stats)
+        state.userLevel = 0
+        #expect(state.selectedTab == .guide)
+    }
+    #endif
 
     @Test("initialLandingTab honors testLandingTabOverride")
     func initialLandingTabHonorsOverride() {


### PR DESCRIPTION
Enable the Status landing tab for Dispatcharr users and redirect streamer-level users to Guide. Add coverage for availability and routing.