### PR TITLE
Replace NEW/REC corner tags with text badges beside program time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ fastlane/test_output
 .claude
 .xcodebuildmcp
 .derivedData
+NexusPVR.xcodeproj/xcshareddata/xcodecloud/manifest.json

--- a/NexusPVR/Design/Theme.swift
+++ b/NexusPVR/Design/Theme.swift
@@ -167,14 +167,40 @@ enum Theme {
 // MARK: - New Badge
 
 struct NewBadge: View {
+    /// Shrinks the label to a single "N" for tight spots (e.g. a guide cell
+    /// where the full word would wrap next to the program's start/end time).
+    var compact: Bool = false
+
     var body: some View {
-        Text("NEW")
+        Text(compact ? "N" : "NEW")
             .font(.system(size: 9, weight: .bold))
             .foregroundStyle(.white)
-            .padding(.horizontal, 5)
+            .padding(.horizontal, compact ? 4 : 5)
             .padding(.vertical, 2)
             .background(Theme.success)
             .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}
+
+// MARK: - Recording Badge
+
+struct RecBadge: View {
+    /// `true` for an in-progress recording, `false` for a recording that's
+    /// merely scheduled (rendered dimmer to distinguish the two).
+    var isActive: Bool = true
+    /// Shrinks the label to a single "R" for tight spots (e.g. a guide cell
+    /// where the full word would wrap next to the program's start/end time).
+    var compact: Bool = false
+
+    var body: some View {
+        Text(compact ? "R" : "REC")
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, compact ? 4 : 5)
+            .padding(.vertical, 2)
+            .background(Theme.recording)
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+            .opacity(isActive ? 1.0 : 0.6)
     }
 }
 

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -23,6 +23,11 @@ struct ChannelsView: View {
     @State private var streamError: String?
     @State private var now = Date()
     @State private var showFilters = false
+    // O(1) recording-status lookup for the current-program badges, mirroring
+    // GuideViewModel's matching: primary by EPG event ID, falling back to
+    // name + start time for servers where epgEventId doesn't line up.
+    @State private var recordingsByEventId: [Int: Recording] = [:]
+    @State private var recordingsByNameAndStart: [String: Recording] = [:]
     #if os(tvOS)
     @FocusState private var focusedChannelId: Int?
     @State private var requestTVSearchKeyboard = false
@@ -253,6 +258,12 @@ struct ChannelsView: View {
                 channelGrid
             }
         }
+        .task {
+            await loadRecordings()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .recordingsDidChange)) { _ in
+            Task { await loadRecordings() }
+        }
     }
 
     /// Re-fetch channels + EPG so channels added server-side appear without
@@ -261,7 +272,32 @@ struct ChannelsView: View {
     /// page.
     private func refreshChannels() async {
         await epgCache.refresh(using: client)
+        await loadRecordings()
         now = Date()
+    }
+
+    /// Loads scheduled/in-progress recordings so channel cards can show the
+    /// NEW/REC badges for the current program.
+    private func loadRecordings() async {
+        do {
+            let (completed, recording, scheduled) = try await client.getAllRecordings()
+            let all = completed + recording + scheduled
+            recordingsByEventId = Dictionary(
+                all.compactMap { r in r.epgEventId.map { ($0, r) } },
+                uniquingKeysWith: { first, _ in first }
+            )
+            recordingsByNameAndStart = Dictionary(
+                all.compactMap { r in r.startTime.map { ("\(r.name.lowercased())_\($0)", r) } },
+                uniquingKeysWith: { first, _ in first }
+            )
+        } catch {
+            // Silently fail - cards just won't show the REC badge
+        }
+    }
+
+    private func recording(for program: Program) -> Recording? {
+        recordingsByEventId[program.id]
+            ?? recordingsByNameAndStart["\(program.name.lowercased())_\(program.start)"]
     }
 
     private func tickCurrentTime() async {
@@ -430,9 +466,13 @@ struct ChannelsView: View {
                 Button {
                     play(channel: channel)
                 } label: {
+                    let program = epgCache.currentProgram(for: channel, at: now)
+                    let rec = program.flatMap { recording(for: $0) }
                     ChannelGridCard(
                         channel: channel,
-                        currentProgram: epgCache.currentProgram(for: channel, at: now)
+                        currentProgram: program,
+                        isScheduledRecording: rec != nil,
+                        isCurrentlyRecording: rec?.recordingStatus == .recording
                     )
                 }
                 .accessibilityIdentifier("channel-card-\(channel.id)")
@@ -896,6 +936,25 @@ struct ChannelGridCard: View {
     @EnvironmentObject private var client: PVRClient
     let channel: Channel
     let currentProgram: Program?
+    var isScheduledRecording: Bool = false
+    var isCurrentlyRecording: Bool = false
+
+    /// NEW badge stacked above REC when both apply, right-aligned next to
+    /// the current program's title.
+    @ViewBuilder
+    private var badgeStack: some View {
+        if let currentProgram, currentProgram.isNew || isScheduledRecording {
+            VStack(alignment: .trailing, spacing: 4) {
+                if currentProgram.isNew {
+                    NewBadge()
+                }
+                if isScheduledRecording {
+                    RecBadge(isActive: isCurrentlyRecording)
+                }
+            }
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.spacingSM) {
             // Logo header
@@ -925,7 +984,7 @@ struct ChannelGridCard: View {
 
             if let program = currentProgram {
                 VStack(alignment: .leading, spacing: 2) {
-                    // Top-aligned so the NEW badge stays on the title's
+                    // Top-aligned so the badges stay level with the title's
                     // first line when the name wraps.
                     HStack(alignment: .top, spacing: 6) {
                         Text(program.cleanName)
@@ -940,7 +999,7 @@ struct ChannelGridCard: View {
                             .multilineTextAlignment(.leading)
                             .fixedSize(horizontal: false, vertical: true)
                         Spacer()
-                        if program.isNew { NewBadge() }
+                        badgeStack
                     }
 
                     // Progress bar

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -1050,6 +1050,11 @@ struct GuideView: View {
 
         let showSport = cellWidth > 200
         let sportIconSize = rowHeight - 10 - 16 // cell height minus padding
+        // cellWidth already reflects the visible/clipped duration for a
+        // currently-airing program (tvOSProgramPosition trims to
+        // visibleStart/visibleEnd), so it alone tells us whether "NEW" /
+        // "REC" would wrap next to the time text.
+        let useCompactBadges = cellWidth < 300
 
         return ZStack {
             HStack(spacing: 6) {
@@ -1063,52 +1068,26 @@ struct GuideView: View {
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
 
-                    Text("\(program.startDate, format: .dateTime.hour().minute()) - \(program.endDate, format: .dateTime.hour().minute())")
-                        .font(.tvScaled(size: 14))
-                        .foregroundStyle(Theme.textSecondary)
+                    HStack(spacing: 4) {
+                        Text("\(program.startDate, format: .dateTime.hour().minute()) - \(program.endDate, format: .dateTime.hour().minute())")
+                            .font(.tvScaled(size: 14))
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+
+                        if program.isNew {
+                            NewBadge(compact: useCompactBadges)
+                        }
+
+                        if isScheduled {
+                            RecBadge(isActive: isRecording, compact: useCompactBadges)
+                        }
+                    }
                 }
 
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-
-            // "New" green band on top-right
-            if program.isNew {
-                VStack {
-                    HStack {
-                        Spacer()
-                        Theme.success
-                            .frame(width: 8, height: 24)
-                            .clipShape(UnevenRoundedRectangle(
-                                topLeadingRadius: 0,
-                                bottomLeadingRadius: 4,
-                                bottomTrailingRadius: 0,
-                                topTrailingRadius: 10
-                            ))
-                    }
-                    Spacer()
-                }
-            }
-
-            // Scheduled/recording red band on bottom-right
-            if isScheduled {
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        Theme.recording
-                            .frame(width: 8, height: 24)
-                            .clipShape(UnevenRoundedRectangle(
-                                topLeadingRadius: 4,
-                                bottomLeadingRadius: 0,
-                                bottomTrailingRadius: 10,
-                                topTrailingRadius: 0
-                            ))
-                            .opacity(isRecording ? 1.0 : 0.6)
-                    }
-                }
-            }
         }
         .frame(width: max(cellWidth - 4, 80), height: rowHeight - 10, alignment: .leading)
         .background(RoundedRectangle(cornerRadius: 10).fill(bgColor))

--- a/NexusPVR/Features/Guide/ProgramCell.swift
+++ b/NexusPVR/Features/Guide/ProgramCell.swift
@@ -52,6 +52,21 @@ struct ProgramCell: View {
         #endif
     }
 
+    /// Room left for the start/end time + badges after the leading padding
+    /// (applied to currently-airing programs to keep text pinned to the
+    /// visible scroll position) eats into the cell's nominal width.
+    private var effectiveWidth: CGFloat {
+        width - (program.isCurrentlyAiring ? leadingPadding : 0)
+    }
+
+    /// Below this, "NEW" / "REC" next to the time text would wrap onto a
+    /// second line, so fall back to single-letter badges instead.
+    /// (ProgramCell is only used on iOS/macOS; tvOS renders its own cell in
+    /// GuideView.swift.)
+    private var useCompactBadges: Bool {
+        effectiveWidth < 180
+    }
+
     var body: some View {
         ZStack(alignment: .leading) {
             // Background
@@ -70,9 +85,20 @@ struct ProgramCell: View {
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
 
-                    Text(timeString)
-                        .font(timeFont)
-                        .foregroundStyle(Theme.textTertiary)
+                    HStack(spacing: 4) {
+                        Text(timeString)
+                            .font(timeFont)
+                            .foregroundStyle(Theme.textTertiary)
+                            .lineLimit(1)
+
+                        if program.isNew {
+                            NewBadge(compact: useCompactBadges)
+                        }
+
+                        if isCurrentlyRecording || isScheduledRecording {
+                            RecBadge(isActive: isCurrentlyRecording, compact: useCompactBadges)
+                        }
+                    }
                 }
 
                 Spacer(minLength: 0)
@@ -81,43 +107,6 @@ struct ProgramCell: View {
             .padding(.leading, Theme.spacingSM + (program.isCurrentlyAiring ? leadingPadding : 0))
             .padding(.trailing, Theme.spacingSM)
             .padding(.vertical, Theme.spacingXS)
-
-            // "New" green band on top-right corner
-            if program.isNew {
-                VStack {
-                    HStack {
-                        Spacer()
-                        Theme.success
-                            .frame(width: 6, height: 20)
-                            .clipShape(UnevenRoundedRectangle(
-                                topLeadingRadius: 0,
-                                bottomLeadingRadius: 3,
-                                bottomTrailingRadius: 0,
-                                topTrailingRadius: Theme.cornerRadiusSM
-                            ))
-                    }
-                    Spacer()
-                }
-            }
-
-            // Recording red band on bottom-right corner
-            if isCurrentlyRecording || isScheduledRecording {
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        Theme.recording
-                            .frame(width: 6, height: 20)
-                            .clipShape(UnevenRoundedRectangle(
-                                topLeadingRadius: 3,
-                                bottomLeadingRadius: 0,
-                                bottomTrailingRadius: Theme.cornerRadiusSM,
-                                topTrailingRadius: 0
-                            ))
-                            .opacity(isCurrentlyRecording ? 1.0 : 0.6)
-                    }
-                }
-            }
 
             // Progress indicator for currently airing
             if program.isCurrentlyAiring {

--- a/NexusPVR/Features/Guide/ProgramDetailView.swift
+++ b/NexusPVR/Features/Guide/ProgramDetailView.swift
@@ -34,6 +34,22 @@ struct ProgramDetailView: View {
 
     var onRecordingChanged: (() -> Void)? = nil
 
+    /// NEW badge stacked above REC when both apply, right-aligned next to
+    /// the title.
+    @ViewBuilder
+    private var badgeStack: some View {
+        if program.isNew || isScheduled {
+            VStack(alignment: .trailing, spacing: 4) {
+                if program.isNew {
+                    NewBadge()
+                }
+                if isScheduled {
+                    RecBadge(isActive: inProgressRecording != nil)
+                }
+            }
+        }
+    }
+
     init(program: Program, channel: Channel, initialRecordingId: Int? = nil, initialCompletedRecording: Recording? = nil, onRecordingChanged: (() -> Void)? = nil) {
         self.program = program
         self.channel = channel
@@ -255,7 +271,7 @@ struct ProgramDetailView: View {
                             .foregroundStyle(Theme.textPrimary)
                             .accessibilityIdentifier("program-detail-name")
                         Spacer()
-                        if program.isNew { NewBadge() }
+                        badgeStack
                     }
 
                     // Row 3: Date | Start time - End time | Duration
@@ -379,7 +395,7 @@ struct ProgramDetailView: View {
                         .foregroundStyle(Theme.textPrimary)
                         .accessibilityIdentifier("program-detail-name")
                     Spacer()
-                    if program.isNew { NewBadge() }
+                    badgeStack
                 }
 
                 if let subtitle = program.subtitle, !subtitle.isEmpty {


### PR DESCRIPTION
## Summary
- Replace the small green/red corner color-band tags in the Guide grid with green **NEW** / red **REC** text badges shown beside the program's start/end time.
- Guide cells fall back to compact single-letter "N"/"R" badges when the available width is too narrow for the full word (currently-airing programs, or short 15–30 min programs) to avoid wrapping.
- Program detail popup: when a program is both new and scheduled/recording, stack the REC badge under the NEW badge.
- Channels tab: load scheduled/in-progress recordings and show the same stacked NEW/REC badges on each channel's current program (previously it only showed NEW, and only next to the title).

## Test plan
- [ ] Guide grid (iOS/macOS): verify NEW/REC badges render beside the time, and shrink to "N"/"R" on narrow/live cells
- [ ] Guide grid (tvOS): same, using the custom tvOS cell renderer
- [ ] Program detail popup (iOS/macOS/tvOS): verify REC stacks under NEW when a program is both new and scheduled/recording
- [ ] Channels tab: verify NEW/REC badges show on the current program per channel, and refresh after scheduling/cancelling a recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)