### PR TITLE
Guide: hide sport icons for short programs

### DIFF
--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -1200,7 +1200,11 @@ struct GuideView: View {
             }
         }()
 
-        let showSport = cellWidth > 200
+        let showSport = GuideSportIconVisibility.shouldShow(
+            for: program,
+            cellWidth: cellWidth,
+            minimumCellWidth: 200
+        )
         let sportIconSize = rowHeight - 10 - 16 // cell height minus padding
         // cellWidth already reflects the visible/clipped duration for a
         // currently-airing program (tvOSProgramPosition trims to

--- a/NexusPVR/Features/Guide/ProgramCell.swift
+++ b/NexusPVR/Features/Guide/ProgramCell.swift
@@ -7,6 +7,19 @@
 
 import SwiftUI
 
+nonisolated enum GuideSportIconVisibility {
+    /// Short Guide cells intentionally stay text-only through this inclusive boundary.
+    static let maximumShortProgramDuration: TimeInterval = 30 * 60
+
+    static func shouldShow(
+        for program: Program,
+        cellWidth: CGFloat,
+        minimumCellWidth: CGFloat
+    ) -> Bool {
+        program.duration > maximumShortProgramDuration && cellWidth > minimumCellWidth
+    }
+}
+
 struct ProgramCell: View {
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -28,9 +41,17 @@ struct ProgramCell: View {
     private var showSportIcon: Bool {
         guard detectedSport != nil else { return false }
         #if os(tvOS)
-        return width > 200
+        return GuideSportIconVisibility.shouldShow(
+            for: program,
+            cellWidth: width,
+            minimumCellWidth: 200
+        )
         #else
-        return width > 100
+        return GuideSportIconVisibility.shouldShow(
+            for: program,
+            cellWidth: width,
+            minimumCellWidth: 100
+        )
         #endif
     }
 

--- a/NexusPVRTests/GuideSportIconVisibilityTests.swift
+++ b/NexusPVRTests/GuideSportIconVisibilityTests.swift
@@ -1,0 +1,58 @@
+//
+//  GuideSportIconVisibilityTests.swift
+//  NexusPVRTests
+//
+//  Coverage for the Guide's sport icon duration and width gates (#137).
+//
+
+import Foundation
+import Testing
+@testable import NextPVR
+
+struct GuideSportIconVisibilityTests {
+    private func program(duration: TimeInterval) -> Program {
+        Program(
+            id: 1,
+            name: "Hockey",
+            subtitle: nil,
+            desc: nil,
+            start: 0,
+            end: Int(duration),
+            genres: ["Sports", "Hockey"],
+            channelId: 1
+        )
+    }
+
+    @Test("Sport icon is hidden for a 30-minute program")
+    func hiddenAtThirtyMinuteBoundary() {
+        #expect(
+            !GuideSportIconVisibility.shouldShow(
+                for: program(duration: 30 * 60),
+                cellWidth: 300,
+                minimumCellWidth: 100
+            )
+        )
+    }
+
+    @Test("Sport icon may be shown for a program longer than 30 minutes")
+    func shownAboveThirtyMinutesWhenWideEnough() {
+        #expect(
+            GuideSportIconVisibility.shouldShow(
+                for: program(duration: 31 * 60),
+                cellWidth: 300,
+                minimumCellWidth: 200
+            )
+        )
+    }
+
+    @Test("Sport icon remains hidden below the platform width threshold")
+    func hiddenWhenCellIsTooNarrow() {
+        #expect(
+            !GuideSportIconVisibility.shouldShow(
+                for: program(duration: 60 * 60),
+                cellWidth: 200,
+                minimumCellWidth: 200
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- hide sport icons for Guide programs lasting 30 minutes or less
- preserve the existing iOS/macOS and tvOS width thresholds for longer programs
- share the visibility rule across the standard and tvOS Guide renderers
- add coverage for the inclusive 30-minute boundary, a longer program, and the width gate

Fixes #137

## Validation

- ✅ NextPVR iOS simulator build
- ✅ NextPVR tvOS simulator build
- ✅ Dispatcharr iOS simulator build
- ⚠️ The three new tests are discovered, but the test target cannot compile under the installed Xcode because of existing actor-isolation errors in `ProgramTests.swift` and `RecordingCodableTests.swift`; no test body is executed.