### PR TITLE
Fix iOS Guide showing the date navigator twice

### DIFF
--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -230,15 +230,9 @@ struct GuideView: View {
         #endif
         #if os(iOS) && DISPATCHERPVR
         .overlay(alignment: .top) {
-            VStack(spacing: 8) {
-                // Only Dispatcharr has catch-up (#119) to browse into the past
-                // for, so this is the one place iOS gets a date navigator at
-                // all — NextPVR's guide stays locked to "today".
-                iOSGuideDateNavBar
-                if viewModel.showFilters && hasFilterData {
-                    filterPanel
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                }
+            if viewModel.showFilters && hasFilterData {
+                filterPanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
         #endif
@@ -457,64 +451,6 @@ struct GuideView: View {
     }
     #endif
 
-    #if os(iOS) && DISPATCHERPVR
-    /// Approximate rendered height of `iOSGuideDateNavBar`, so
-    /// `guideTopPadding` can reserve space for it above the grid.
-    private let iOSDateNavBarHeight: CGFloat = 40
-
-    /// iOS has no macOS-style floating nav bar and no tvOS header row, so
-    /// catch-up (#119) needs its own way to reach past days here. Mirrors
-    /// `macOSGuideNavBar`'s chevron/date/chevron shape, plus a "Today"
-    /// shortcut back once the user has navigated away.
-    private var iOSGuideDateNavBar: some View {
-        HStack(spacing: 12) {
-            Button {
-                viewModel.previousDay()
-                Task { await viewModel.navigateToDate(using: client) }
-            } label: {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(viewModel.canGoToPreviousDay ? Theme.accent : Theme.textTertiary)
-                    .frame(width: 32, height: 32)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(!viewModel.canGoToPreviousDay)
-
-            Text(viewModel.selectedDate, format: .dateTime.weekday(.abbreviated).month(.abbreviated).day())
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(Theme.textPrimary)
-
-            Button {
-                viewModel.nextDay()
-                Task { await viewModel.navigateToDate(using: client) }
-            } label: {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Theme.accent)
-                    .frame(width: 32, height: 32)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if !viewModel.isOnToday {
-                Button("Today") {
-                    viewModel.scrollToNow()
-                    Task { await viewModel.navigateToDate(using: client) }
-                }
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(Theme.accent)
-                .buttonStyle(.plain)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, Theme.spacingMD)
-        .frame(height: iOSDateNavBarHeight)
-        .background(.ultraThinMaterial)
-    }
-    #endif
-
     #if !os(tvOS)
 
     private var guideTopPadding: CGFloat {
@@ -526,11 +462,6 @@ struct GuideView: View {
         #endif
         #if DISPATCHERPVR
         var extra: CGFloat = 0
-        #if os(iOS)
-        // Space for the floating date navigator (#119) — always shown on
-        // Dispatcharr's iOS guide since catch-up needs a way to reach past days.
-        extra += iOSDateNavBarHeight
-        #endif
         if viewModel.showFilters && hasFilterData {
             // Add space for each filter row shown
             extra += 8 // top/bottom padding

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -473,9 +473,9 @@ struct IOSNavigation: View {
             } label: {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(guideViewModel.isOnToday ? Theme.textTertiary : Theme.accent)
+                    .foregroundStyle(guideViewModel.canGoToPreviousDay ? Theme.accent : Theme.textTertiary)
             }
-            .disabled(guideViewModel.isOnToday)
+            .disabled(!guideViewModel.canGoToPreviousDay)
 
             Text(guideViewModel.selectedDate, format: .dateTime.month(.abbreviated).day())
                 .font(.subheadline.weight(.medium))
@@ -490,6 +490,17 @@ struct IOSNavigation: View {
             }
 
             #if DISPATCHERPVR
+            // Catch-up (#119) lets the guide browse into the past on iOS, so
+            // offer a quick way back once the user has navigated away.
+            if !guideViewModel.isOnToday {
+                Button("Today") {
+                    guideViewModel.scrollToNow()
+                    Task { await guideViewModel.navigateToDate(using: client) }
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.accent)
+            }
+
             if !epgCache.channelProfiles.isEmpty || epgCache.channelGroups.contains(where: { group in
                 epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
             }) {


### PR DESCRIPTION
Fixes #136.

## Root cause
PR #119 (XC Catch-up / #130) added `iOSGuideDateNavBar` as a content overlay in `GuideView.swift`, believing it was "the one place iOS gets a date navigator" — but `IOSNavigation.iOSGuideToolbarContent` (`NavigationRouter.swift`) already renders an identical prev/date/next control in the nav bar toolbar for every iOS build. On the Dispatcharr (`DISPATCHERPVR`) scheme, both mounted at once and stayed in lockstep (same `GuideViewModel` instance), producing two visible day navigators. This only affects the Dispatcharr scheme on iOS — NextPVR never rendered the overlay, and macOS/tvOS each have their own single, separate nav bar.

## Change
- Removed the duplicate `iOSGuideDateNavBar` overlay and its `iOSDateNavBarHeight` top-padding reservation from `GuideView.swift`.
- Moved its "Today" shortcut into `iOSGuideToolbarContent`, gated to `DISPATCHERPVR` same as before.
- Fixed the toolbar's previous-day button to use `canGoToPreviousDay` (respects the earliest cached EPG date / catch-up limits) instead of the older `isOnToday` check — this matches the removed overlay and the macOS/tvOS controls, which already used the correct logic.

## Testing
- `xcodebuild build` for both `Dispatcharr` and `NextPVR` schemes on iOS Simulator — both succeed.
- Manual review: single date navigator remains in the nav bar for both schemes; filter panel, "Today" shortcut, and day-limit disabling all preserved.

## Acceptance criteria (from #136)
- [x] Guide shows exactly one date navigation control on iPhone/iPad
- [x] Previous-day, next-day, and selected-date behavior continue to work
- [x] No lifecycle path creates a second copy (removed the second source entirely, not a mount-order fix)
- [x] macOS and tvOS Guide layouts unchanged