### PR TITLE
Offer catch-up from the beginning for airing programmes (#143)

### DIFF
--- a/NexusPVR/Core/Models/CatchupAvailability.swift
+++ b/NexusPVR/Core/Models/CatchupAvailability.swift
@@ -35,6 +35,29 @@ nonisolated enum CatchupAvailability {
         return program.startDate >= earliestStart
     }
 
+    /// Whether a **currently airing** `program` can be restarted from its
+    /// scheduled start via catch-up (#143).
+    ///
+    /// Same channel/window gating as `isAvailable`, but for the live case:
+    /// the program must have started and not yet ended. The archive segment
+    /// for the already-aired portion is what the mint call asks for, so the
+    /// start still has to fall inside the rolling `catchup_days` window.
+    /// As with `isAvailable`, the server remains the source of truth.
+    static func isAvailableFromStart(
+        program: Program,
+        channelIsCatchup: Bool,
+        catchupDays: Int,
+        now: Date = Date()
+    ) -> Bool {
+        guard channelIsCatchup, catchupDays > 0 else { return false }
+        // Only the live window — ended programs go through `isAvailable`.
+        guard program.startDate <= now, now < program.endDate else { return false }
+        guard let earliestStart = Calendar.current.date(byAdding: .day, value: -catchupDays, to: now) else {
+            return false
+        }
+        return program.startDate >= earliestStart
+    }
+
     /// Filters a channel's cached EPG down to playable archive entries and
     /// orders the list newest-first for the channel catch-up browser.
     static func availablePrograms(

--- a/NexusPVR/Features/Guide/ProgramDetailView.swift
+++ b/NexusPVR/Features/Guide/ProgramDetailView.swift
@@ -486,6 +486,19 @@ struct ProgramDetailView: View {
             catchupDays: channel.catchupDays
         )
     }
+
+    /// Whether the currently airing program can be restarted from its
+    /// scheduled start via catch-up (#143). Also requires the channel UUID
+    /// the mint call needs, so the button stays hidden when that metadata
+    /// hasn't been loaded.
+    private var catchupFromStartAvailable: Bool {
+        guard client.channelUUID(forChannelId: channel.id) != nil else { return false }
+        return CatchupAvailability.isAvailableFromStart(
+            program: program,
+            channelIsCatchup: channel.isCatchup,
+            catchupDays: channel.catchupDays
+        )
+    }
     #endif
 
     private var actionSection: some View {
@@ -576,6 +589,36 @@ struct ProgramDetailView: View {
                     }
                     #endif
                 }
+
+                #if DISPATCHERPVR
+                // Restart the airing program from its scheduled start using
+                // the same catch-up session API as the archive flow (#143).
+                // Skipped when an in-progress recording already offers its own
+                // "Watch from Beginning" button just above.
+                if catchupFromStartAvailable, completedRecording == nil, inProgressRecording == nil {
+                    Button {
+                        watchCatchup()
+                    } label: {
+                        HStack {
+                            if isStartingCatchup {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Image(systemName: "backward.end.fill")
+                                Text("Watch from Beginning")
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    #if os(tvOS)
+                    .buttonStyle(TVProgramPopupButtonStyle(variant: .accent))
+                    #else
+                    .buttonStyle(AccentButtonStyle())
+                    #endif
+                    .disabled(isStartingCatchup)
+                    .accessibilityIdentifier("watch-from-beginning-catchup-button")
+                }
+                #endif
 
                 Button {
                     watchLive()

--- a/NexusPVRTests/CatchupAvailabilityTests.swift
+++ b/NexusPVRTests/CatchupAvailabilityTests.swift
@@ -84,4 +84,44 @@ struct CatchupAvailabilityTests {
 
         #expect(results.map(\.id) == [2, 1])
     }
+
+    // MARK: - Restart-from-start gating (#143)
+
+    @Test("Airing program can be restarted from its start when catch-up is on")
+    func airingRestartAvailable() {
+        let now = Date()
+        let p = program(startingHoursAgo: 0.25, durationMinutes: 60, now: now)
+        #expect(CatchupAvailability.isAvailableFromStart(program: p, channelIsCatchup: true, catchupDays: 7, now: now))
+    }
+
+    @Test("Restart-from-start is off for channels without catch-up or with a zero window")
+    func airingRestartRequiresCatchupChannel() {
+        let now = Date()
+        let p = program(startingHoursAgo: 0.25, durationMinutes: 60, now: now)
+        #expect(!CatchupAvailability.isAvailableFromStart(program: p, channelIsCatchup: false, catchupDays: 7, now: now))
+        #expect(!CatchupAvailability.isAvailableFromStart(program: p, channelIsCatchup: true, catchupDays: 0, now: now))
+    }
+
+    @Test("Restart-from-start is off for ended programs — those use isAvailable")
+    func endedProgramIsNotRestartable() {
+        let now = Date()
+        let p = program(startingHoursAgo: 5, durationMinutes: 60, now: now)
+        #expect(!CatchupAvailability.isAvailableFromStart(program: p, channelIsCatchup: true, catchupDays: 7, now: now))
+        #expect(CatchupAvailability.isAvailable(program: p, channelIsCatchup: true, catchupDays: 7, now: now))
+    }
+
+    @Test("Restart-from-start is off for a program that hasn't started yet")
+    func futureProgramIsNotRestartable() {
+        let now = Date()
+        let p = program(startingHoursAgo: -1, durationMinutes: 60, now: now)
+        #expect(!CatchupAvailability.isAvailableFromStart(program: p, channelIsCatchup: true, catchupDays: 7, now: now))
+    }
+
+    @Test("An airing program that started before the archive window can't be restarted")
+    func airingProgramOutsideWindow() {
+        let now = Date()
+        // Marathon broadcast that started 10 days ago and is still running.
+        let p = program(startingHoursAgo: 24 * 10, durationMinutes: 60 * 24 * 11, now: now)
+        #expect(!CatchupAvailability.isAvailableFromStart(program: p, channelIsCatchup: true, catchupDays: 7, now: now))
+    }
 }

--- a/NexusPVRUITests/NexusPVRUITests.swift
+++ b/NexusPVRUITests/NexusPVRUITests.swift
@@ -51,6 +51,64 @@ final class NexusPVRUITests: XCTestCase {
         XCTAssertTrue(waitForGuideContent(in: app), "Guide should be visible after player dismissal")
     }
 
+    #if os(iOS)
+    /// A currently airing program offers `Watch Live`, and the catch-up
+    /// restart action (#143) is a separate control — never the same button.
+    /// Demo/NextPVR data has no catch-up channels, so the restart action is
+    /// expected to be absent there; when a catch-up channel is present it must
+    /// coexist with `Watch Live` rather than replace it.
+    @MainActor
+    func testLiveProgramDetailOffersLiveAndCatchupAsDistinctActions() throws {
+        let app = launchApp()
+        navigateToTab("Guide", app: app)
+        XCTAssertTrue(waitForGuideContent(in: app), "Guide content should be loaded before opening details")
+
+        let watchLive = app.buttons["watch-live-button"].firstMatch
+        let watchFromBeginning = app.buttons["watch-from-beginning-catchup-button"].firstMatch
+
+        let programButtons = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'guide-program-'"))
+        XCTAssertTrue(waitForCondition(timeout: 5) { programButtons.count > 0 })
+
+        var foundLiveProgram = false
+        for index in 0..<min(programButtons.count, 12) {
+            let button = programButtons.element(boundBy: index)
+            guard button.exists else { continue }
+            let frame = button.frame
+            guard frame.width > 1, frame.height > 1 else { continue }
+            button.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            pause(1.0)
+
+            if watchLive.waitForExistence(timeout: 1.5) {
+                foundLiveProgram = true
+                break
+            }
+
+            if app.otherElements["player-view"].exists {
+                dismissPlayer(app: app)
+            } else {
+                dismissPresentedDetail(app: app)
+            }
+            pause(0.3)
+        }
+
+        try XCTSkipUnless(foundLiveProgram, "No currently airing program was reachable in the visible guide window")
+
+        XCTAssertTrue(watchLive.exists, "A currently airing program should offer Watch Live")
+        XCTAssertTrue(watchLive.isEnabled, "Watch Live should be actionable for an airing program")
+
+        if watchFromBeginning.exists {
+            XCTAssertTrue(watchFromBeginning.isEnabled, "Catch-up restart should be actionable when offered")
+            XCTAssertNotEqual(
+                watchFromBeginning.frame,
+                watchLive.frame,
+                "Watch from Beginning and Watch Live must be two distinct controls"
+            )
+        }
+
+        dismissPresentedDetail(app: app)
+    }
+    #endif
+
     @MainActor
     func testSchedulingFromGuideAppearsInScheduledRecordings() throws {
         let app = launchApp()


### PR DESCRIPTION
Closes #143.

Adds a Dispatcharr-only **Watch from Beginning** action to the programme detail surface for currently airing programmes, alongside **Watch Live**.

## Changes

- **`CatchupAvailability.isAvailableFromStart`** — new gating for the live window (`start <= now < end`) against the channel's rolling `catchup_days` archive, mirroring the existing `isAvailable` gating used for ended programmes.
- **`ProgramDetailView`** — new button rendered above `Watch Live` inside the `isCurrentlyAiring` branch. It reuses the existing `watchCatchup()` path from #119, which already mints the session at the programme's scheduled start and resolves the playback URL via `CatchupService`, so there is no second playback path. The button additionally requires a known channel UUID, and is suppressed when a completed or in-progress recording already offers its own "Watch from Beginning". Session/playback errors surface in the existing alert and the sheet is only dismissed once playback starts.
- `Watch Live` is untouched and still starts the live stream. Past programmes keep the existing catch-up flow. NextPVR behaviour is unchanged.

## Tests

- 5 new `CatchupAvailabilityTests` cases: airing + catch-up channel → available; non-catch-up / zero-day window → not; ended programme → not (still covered by `isAvailable`); future programme → not; airing programme that started outside the archive window → not.
- New iOS UI test `testLiveProgramDetailOffersLiveAndCatchupAsDistinctActions`: opens a currently airing programme's detail, asserts `Watch Live` exists and is enabled, and asserts the catch-up restart is a separate control when offered (absent in demo data, which has no catch-up channels).
- Both schemes (`NextPVR`, `Dispatcharr`) build for iOS Simulator; the unit suite and the new UI test pass.
