### PR TITLE
Add automatic deinterlacing for interlaced live TV streams (#142)

### DIFF
--- a/NexusPVR/Core/Models/DeinterlaceMode.swift
+++ b/NexusPVR/Core/Models/DeinterlaceMode.swift
@@ -1,0 +1,49 @@
+//
+//  DeinterlaceMode.swift
+//  nextpvr-apple-client
+//
+//  Convenience typealias for the deinterlacing mode enum (#142). The
+//  canonical definition lives inside `UserPreferences` so the tvOS Top
+//  Shelf extension (which only shares `UserPreferences.swift` from the
+//  Core/Models folder) keeps compiling without needing this sibling file
+//  to also be in its membership list.
+//
+
+typealias DeinterlaceMode = UserPreferences.DeinterlaceMode
+
+extension DeinterlaceMode {
+    /// Value passed to mpv's `deinterlace` option.
+    ///
+    /// - `auto` lets mpv deinterlace only streams the demuxer/decoder flags as
+    ///   interlaced, so progressive channels are passed through untouched.
+    /// - `on` forces the filter on, for broadcasts that are interlaced but
+    ///   carry no (or wrong) interlacing flags.
+    nonisolated var mpvValue: String {
+        switch self {
+        case .off: return "no"
+        case .auto: return "auto"
+        case .on: return "yes"
+        }
+    }
+
+    /// SF Symbol shown next to the option in Settings.
+    nonisolated var icon: String {
+        switch self {
+        case .off: return "rectangle.slash"
+        case .auto: return "wand.and.stars"
+        case .on: return "rectangle.on.rectangle"
+        }
+    }
+
+    /// Explanatory text shown under the picker in Settings.
+    nonisolated var summary: String {
+        switch self {
+        case .off:
+            return "Interlaced broadcasts (1080i50, 576i50) may show combing during motion."
+        case .auto:
+            return "Deinterlaces only streams flagged as interlaced; progressive channels are untouched."
+        case .on:
+            return "Always deinterlaces. Use only if interlaced channels are not detected automatically."
+        }
+    }
+}

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -18,6 +18,10 @@ nonisolated struct UserPreferences: Codable {
     var subtitleMode: SubtitleMode = .manual
     var subtitleSize: SubtitleSize = .medium
     var subtitleBackground: Bool = true
+    /// Deinterlacing mode applied by the player (#142). Defaults to `.auto`
+    /// so interlaced broadcasts (DVB 1080i50 / 576i50, ATSC 1080i60) play
+    /// without combing while progressive channels are left untouched.
+    var deinterlaceMode: DeinterlaceMode = .auto
     /// User-selectable tvOS UI font size (#107). Default `.medium`
     /// preserves the pre-feature visual output exactly — existing
     /// users see zero change on first launch after upgrade.
@@ -62,6 +66,25 @@ nonisolated struct UserPreferences: Codable {
     var theme: AppTheme {
         get { AppTheme(rawValue: themeRawValue) ?? .system }
         set { themeRawValue = newValue.rawValue }
+    }
+
+    /// User-selectable deinterlacing mode (#142). Nested here for the same
+    /// reason as `AppTheme` — the tvOS Top Shelf extension shares
+    /// `UserPreferences.swift` but not its sibling Core/Models files.
+    nonisolated enum DeinterlaceMode: String, CaseIterable, Identifiable, Codable {
+        case off = "Off"
+        case auto = "Auto"
+        case on = "On"
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .off: return "Off"
+            case .auto: return "Automatic"
+            case .on: return "Always On"
+            }
+        }
     }
 
     /// User-selectable appearance override (#108). Nested here for the same
@@ -130,6 +153,7 @@ nonisolated struct UserPreferences: Codable {
         case subtitleMode
         case subtitleSize
         case subtitleBackground
+        case deinterlaceMode
         case uiFontSize
         case preferredSubtitleLanguage
         case guideShowGroupsInSidebar
@@ -163,6 +187,9 @@ nonisolated struct UserPreferences: Codable {
         subtitleMode = try container.decodeIfPresent(SubtitleMode.self, forKey: .subtitleMode) ?? .manual
         subtitleSize = try container.decodeIfPresent(SubtitleSize.self, forKey: .subtitleSize) ?? .medium
         subtitleBackground = try container.decodeIfPresent(Bool.self, forKey: .subtitleBackground) ?? true
+        // Prefs written before #142 have no `deinterlaceMode`; they decode to
+        // .auto, which is the recommended default for broadcast streams.
+        deinterlaceMode = try container.decodeIfPresent(DeinterlaceMode.self, forKey: .deinterlaceMode) ?? .auto
         // Forward- and backward-compat: a blob without `uiFontSize`
         // (any prefs written before #107) decodes to .medium so
         // existing users see no visual change.
@@ -190,6 +217,7 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(subtitleMode, forKey: .subtitleMode)
         try container.encode(subtitleSize, forKey: .subtitleSize)
         try container.encode(subtitleBackground, forKey: .subtitleBackground)
+        try container.encode(deinterlaceMode, forKey: .deinterlaceMode)
         try container.encode(uiFontSize, forKey: .uiFontSize)
         try container.encodeIfPresent(preferredSubtitleLanguage, forKey: .preferredSubtitleLanguage)
         try container.encode(guideShowGroupsInSidebar, forKey: .guideShowGroupsInSidebar)

--- a/NexusPVR/Features/Player/MPVPlayerCore.swift
+++ b/NexusPVR/Features/Player/MPVPlayerCore.swift
@@ -803,6 +803,18 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
         // software permanently before the first IDR frame arrives.
         mpv_set_option_string(mpv, "vd-lavc-software-fallback", "600")
 
+        // Deinterlacing (#142) — DVB/ATSC broadcasts are frequently interlaced
+        // (1080i50, 576i50, 1080i60). Without a deinterlacer these show combing
+        // and judder, worst during sport. `auto` (the default preference) only
+        // filters streams flagged as interlaced, so progressive channels are
+        // passed through unchanged. Field parity is taken from the stream.
+        // Note: on Apple platforms there is no VideoToolbox deinterlacer, so
+        // mpv runs the filter in software — hardware-decoded frames are
+        // downloaded automatically when the filter kicks in.
+        let deinterlaceMode = UserPreferences.load().deinterlaceMode
+        mpv_set_option_string(mpv, "deinterlace", deinterlaceMode.mpvValue)
+        mpv_set_option_string(mpv, "deinterlace-field-parity", "auto")
+
         // CPU threading for software decode (MPV recommends max 16)
         let threadCount = min(ProcessInfo.processInfo.processorCount * 2, 16)
         mpv_set_option_string(mpv, "vd-lavc-threads", "\(threadCount)")

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     @State private var subtitleMode: SubtitleMode = UserPreferences.load().subtitleMode
     @State private var subtitleSize: SubtitleSize = UserPreferences.load().subtitleSize
     @State private var subtitleBackground: Bool = UserPreferences.load().subtitleBackground
+    @State private var deinterlaceMode: DeinterlaceMode = UserPreferences.load().deinterlaceMode
     @State private var landingTab: LandingTabOption = UserPreferences.load().landingTab
     @State private var hideRecordings: Bool = UserPreferences.load().hideRecordings
     @State private var theme: AppTheme = UserPreferences.load().theme
@@ -61,6 +62,7 @@ struct SettingsView: View {
         case subtitleMode
         case subtitleSize
         case subtitleBackground
+        case deinterlace
         case renderer
         case landingTab
         case hideRecordings
@@ -219,6 +221,14 @@ struct SettingsView: View {
                                 icon: "speaker.wave.2"
                             ) {
                                 activeTVPopup = .audioOutput
+                            }
+                            tvSettingsRow(
+                                title: "Deinterlacing",
+                                value: deinterlaceMode.label,
+                                icon: deinterlaceMode.icon,
+                                detail: deinterlaceDescription
+                            ) {
+                                activeTVPopup = .deinterlace
                             }
                             tvSettingsRow(
                                 title: "Subtitles",
@@ -767,6 +777,8 @@ struct SettingsView: View {
             return "Seek Forward"
         case .audioOutput:
             return "Audio Output"
+        case .deinterlace:
+            return "Deinterlacing"
         case .subtitleMode:
             return "Subtitles"
         case .subtitleSize:
@@ -845,6 +857,20 @@ struct SettingsView: View {
                     prefs.save()
                 }
             ]
+        case .deinterlace:
+            return DeinterlaceMode.allCases.map { mode in
+                TVPopupOption(
+                    id: "settings-popup-deinterlace-\(mode.rawValue)",
+                    title: mode.label,
+                    isCurrent: deinterlaceMode == mode,
+                    isDestructive: false
+                ) {
+                    deinterlaceMode = mode
+                    var prefs = UserPreferences.load()
+                    prefs.deinterlaceMode = mode
+                    prefs.save()
+                }
+            }
         case .subtitleMode:
             return [
                 TVPopupOption(id: "settings-popup-subtitle-manual", title: "Manual", isCurrent: subtitleMode == .manual, isDestructive: false) {
@@ -1139,6 +1165,15 @@ struct SettingsView: View {
                 Text("Stereo").tag("stereo")
             }
 
+            Picker("Deinterlacing", selection: $deinterlaceMode) {
+                ForEach(DeinterlaceMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            Text(deinterlaceDescription)
+                .font(.caption)
+                .foregroundStyle(Theme.textTertiary)
+
             Picker("Subtitles", selection: $subtitleMode) {
                 Text("Manual").tag(SubtitleMode.manual)
                 Text("Auto").tag(SubtitleMode.auto)
@@ -1192,6 +1227,11 @@ struct SettingsView: View {
             prefs.audioChannels = audioChannels
             prefs.save()
         }
+        .onChange(of: deinterlaceMode) { _ in
+            var prefs = UserPreferences.load()
+            prefs.deinterlaceMode = deinterlaceMode
+            prefs.save()
+        }
         .onChange(of: subtitleMode) { _ in
             var prefs = UserPreferences.load()
             prefs.subtitleMode = subtitleMode
@@ -1229,6 +1269,13 @@ struct SettingsView: View {
         case .auto:
             return "Automatically select the last used subtitle language when available."
         }
+    }
+
+    /// Explains the selected deinterlacing mode (#142). Changing the mode
+    /// takes effect the next time playback starts, since mpv is configured
+    /// when the player is created.
+    private var deinterlaceDescription: String {
+        deinterlaceMode.summary + " Applies to the next stream you play."
     }
 
     private func rendererDescription(for api: GPUAPI) -> String {

--- a/NexusPVRTests/UserPreferencesTests.swift
+++ b/NexusPVRTests/UserPreferencesTests.swift
@@ -23,6 +23,7 @@ struct UserPreferencesTests {
         prefs.audioChannels = "stereo"
         prefs.subtitleSize = .large
         prefs.subtitleBackground = false
+        prefs.deinterlaceMode = .on
         prefs.preferredSubtitleLanguage = "eng"
         prefs.landingTab = .channels
         prefs.hideRecordings = true
@@ -38,6 +39,7 @@ struct UserPreferencesTests {
         #expect(decoded.audioChannels == prefs.audioChannels)
         #expect(decoded.subtitleSize == prefs.subtitleSize)
         #expect(decoded.subtitleBackground == prefs.subtitleBackground)
+        #expect(decoded.deinterlaceMode == prefs.deinterlaceMode)
         #expect(decoded.preferredSubtitleLanguage == prefs.preferredSubtitleLanguage)
         #expect(decoded.landingTab == prefs.landingTab)
         #expect(decoded.landingTabRawValue == prefs.landingTabRawValue)
@@ -57,6 +59,7 @@ struct UserPreferencesTests {
         #expect(prefs.audioChannels == "auto")
         #expect(prefs.subtitleSize == .medium)
         #expect(prefs.subtitleBackground == true)
+        #expect(prefs.deinterlaceMode == .auto)
         #expect(prefs.preferredSubtitleLanguage == nil)
         #expect(prefs.landingTab == .guide)
         #expect(prefs.landingTabRawValue == LandingTabOption.guide.rawValue)
@@ -64,6 +67,22 @@ struct UserPreferencesTests {
         #expect(prefs.theme == .system)
         #expect(prefs.themeRawValue == AppTheme.system.rawValue)
         #expect(prefs.updatedAt == .distantPast)
+    }
+
+    @Test("Decoding prefs written before deinterlacing defaults to Automatic")
+    func decodeLegacyWithoutDeinterlaceMode() throws {
+        // Blobs saved before #142 carry no `deinterlaceMode`; existing users
+        // get the recommended automatic mode rather than a decode failure.
+        let json = #"{"keywords": ["news"], "audioChannels": "stereo"}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.deinterlaceMode == .auto)
+    }
+
+    @Test("DeinterlaceMode maps to the matching mpv option value")
+    func deinterlaceModeMpvValues() {
+        #expect(DeinterlaceMode.off.mpvValue == "no")
+        #expect(DeinterlaceMode.auto.mpvValue == "auto")
+        #expect(DeinterlaceMode.on.mpvValue == "yes")
     }
 
     @Test("Decoding legacy JSON without landingTab defaults to Guide")


### PR DESCRIPTION
Fixes #142.

Interlaced DVB/ATSC broadcasts (1080i50, 576i50, 1080i60) showed combing and judder because mpv was never told to deinterlace. This enables mpv's deinterlacer and exposes the mode as a playback setting.

## Changes

- **`Core/Models/DeinterlaceMode.swift`** (new) — typealias + `mpvValue` (`no` / `auto` / `yes`), SF Symbol, and summary text. The enum itself is nested in `UserPreferences` (same pattern as `AppTheme` / `LandingTabOption`) so the Top Shelf extension keeps compiling from that single shared file.
- **`UserPreferences`** — new `deinterlaceMode` defaulting to `.auto`, with a `decodeIfPresent … ?? .auto` fallback so prefs written before this change (including older iCloud blobs) decode cleanly.
- **`MPVPlayerCore.setup()`** — sets `deinterlace` from the preference plus `deinterlace-field-parity=auto`, so field order (top-field-first for DVB) comes from the stream. mpv 0.41's auto-inserted bwdif runs at field rate: 1080i50 → 50 fps, 1080i60 → 59.94 fps, preserving motion during sport.
- **Settings › Playback** — a Deinterlacing picker (Off / Automatic / Always On) on iOS/macOS and the equivalent row + popup on tvOS, with a caption explaining the mode.
- **Tests** — round-trip, defaults, legacy-blob, and mpv-value-mapping coverage in `UserPreferencesTests`.

`Automatic` is the default and only filters streams flagged as interlaced, so progressive channels are unchanged.

## Caveat

Apple platforms have no VideoToolbox deinterlacer, so mpv runs bwdif in software and downloads hardware-decoded frames when the filter engages. On 1080i50 this costs CPU on older Apple TVs — `Automatic` keeps that cost to genuinely interlaced channels, and `Off` is available for constrained hardware.

The mode is read when the player is created, so a change applies to the next stream played; there is no live in-player toggle.

## Verification

- Builds clean: iOS (NextPVR), iOS (Dispatcharr), tvOS (NextPVR + Top Shelf).
- `UserPreferencesTests` 17/17 pass on the iOS simulator.
