### PR TITLE
Open the guide at the current time with catch-up enabled (#140)

### DIFF
--- a/NexusPVR/Features/Guide/GuideScrollHelper.swift
+++ b/NexusPVR/Features/Guide/GuideScrollHelper.swift
@@ -45,6 +45,27 @@ nonisolated enum GuideScrollHelper {
         return "scroll-\(scrollTimestamp)"
     }
 
+    /// Horizontal distance, in points, between the timeline's left edge and
+    /// `scrollTarget` — i.e. where the guide should sit once it has been
+    /// positioned at the current time (#140).
+    ///
+    /// Catch-up builds keep the whole day in the timeline, so the guide opens
+    /// at midnight and has to scroll right to reach "now". A caller can compare
+    /// this against the observed scroll offset to tell whether its initial
+    /// `scrollTo` actually took effect, and retry while the answer is no.
+    /// Returns 0 when the target is at or before the timeline start (the
+    /// non-catch-up case, where the timeline already begins at the current
+    /// half-hour and no scrolling is needed).
+    static func expectedScrollOffsetX(
+        timelineStart: Date,
+        scrollTarget: Date,
+        hourWidth: CGFloat
+    ) -> CGFloat {
+        let seconds = scrollTarget.timeIntervalSince(timelineStart)
+        guard seconds > 0 else { return 0 }
+        return CGFloat(seconds / 3600) * hourWidth
+    }
+
     /// Calculates the leading padding for a program cell to align text with the visible scroll position
     /// - Parameters:
     ///   - programStart: The program's start time

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -719,6 +719,56 @@ struct GuideView: View {
 
     #if !os(tvOS)
     @State private var scrollViewHeight: CGFloat = 0
+    /// Guards the once-per-appearance current-time positioning (#140).
+    @State private var hasCompletedInitialScroll = false
+    @State private var initialScrollTask: Task<Void, Never>?
+
+    /// Positions the timeline on the current half-hour when the guide appears.
+    ///
+    /// Catch-up builds keep the whole day in the timeline, so the grid starts
+    /// at midnight and only reaches "now" by scrolling. A single scroll
+    /// request issued before the rows have landed is silently dropped, which
+    /// left the guide sitting at 00:00 on first launch (#140) — so this
+    /// retries until the observed offset shows the scroll took effect.
+    /// Navigating the timeline afterwards moves the offset too, which ends the
+    /// retries as well: the guide never yanks itself back.
+    private func startInitialScroll(using proxy: ScrollViewProxy) {
+        guard !hasCompletedInitialScroll, initialScrollTask == nil else { return }
+
+        #if os(macOS)
+        let hasCatchupReturnTarget = appState.catchupGuideReturnTime != nil
+        #else
+        let hasCatchupReturnTarget = false
+        #endif
+        guard !hasCatchupReturnTarget, !preservesGuidePositionAfterCatchup else { return }
+
+        // Nothing to scroll against until the grid has rows.
+        guard !viewModel.channels.isEmpty else { return }
+
+        initialScrollTask = Task { @MainActor in
+            defer { initialScrollTask = nil }
+            hasCompletedInitialScroll = true
+
+            guard let targetId = updateScrollTarget() else { return }
+            let expectedOffset = GuideScrollHelper.expectedScrollOffsetX(
+                timelineStart: viewModel.timelineStart,
+                scrollTarget: currentTimelineHour ?? viewModel.timelineStart,
+                hourWidth: hourWidth
+            )
+
+            for attempt in 0..<8 {
+                proxy.scrollTo(targetId, anchor: UnitPoint(x: 0.10, y: 0))
+                try? await Task.sleep(for: .milliseconds(attempt == 0 ? 150 : 300))
+                guard !Task.isCancelled else { return }
+                // `anchor` leaves the target inset from the leading edge, so
+                // compare against a fraction of the expected distance rather
+                // than the exact value.
+                if expectedOffset <= 1 || gridHorizontalOffset > expectedOffset * 0.5 {
+                    return
+                }
+            }
+        }
+    }
 
     private var iOSMacOSGuideContent: some View {
         // Main grid — single LazyVStack for guaranteed lazy rendering
@@ -825,20 +875,20 @@ struct GuideView: View {
             }
             #endif
             .onAppear {
-                #if os(macOS)
-                let hasCatchupReturnTarget = appState.catchupGuideReturnTime != nil
-                #else
-                let hasCatchupReturnTarget = false
-                #endif
-
-                if !hasCatchupReturnTarget && !preservesGuidePositionAfterCatchup {
-                    updateScrollTarget()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                        if let targetId = scrollTargetId {
-                            programProxy.scrollTo(targetId, anchor: UnitPoint(x: 0.10, y: 0))
-                        }
-                    }
-                }
+                startInitialScroll(using: programProxy)
+            }
+            .onChange(of: viewModel.channels.count) {
+                // The first rows can land after the grid appears; a scroll
+                // requested against an empty grid never sticks (#140).
+                startInitialScroll(using: programProxy)
+            }
+            .onChange(of: epgCache.isFullyLoaded) {
+                startInitialScroll(using: programProxy)
+            }
+            .onDisappear {
+                initialScrollTask?.cancel()
+                initialScrollTask = nil
+                hasCompletedInitialScroll = false
             }
             #if os(macOS)
             .task {

--- a/NexusPVRTests/GuideScrollHelperTests.swift
+++ b/NexusPVRTests/GuideScrollHelperTests.swift
@@ -569,4 +569,49 @@ struct GuideScrollHelperTests {
         #expect(isAiring2 == true)
         #expect(padding2 == 0) // Program still starts at scroll target
     }
+
+    // MARK: - Initial current-time positioning (#140)
+
+    @Test("Expected offset spans midnight to the current half-hour on catch-up timelines")
+    func expectedOffsetFromMidnight() {
+        let calendar = Calendar.current
+        let midnight = calendar.startOfDay(for: Date())
+        let target = makeDate(hour: 16, minute: 30)
+        let offset = GuideScrollHelper.expectedScrollOffsetX(
+            timelineStart: midnight,
+            scrollTarget: target,
+            hourWidth: 100
+        )
+        #expect(offset == 1650) // 16.5 hours * 100pt
+    }
+
+    @Test("Expected offset is zero when the timeline already starts at the target")
+    func expectedOffsetAtTimelineStart() {
+        let target = makeDate(hour: 9, minute: 0)
+        let offset = GuideScrollHelper.expectedScrollOffsetX(
+            timelineStart: target,
+            scrollTarget: target,
+            hourWidth: 100
+        )
+        #expect(offset == 0)
+    }
+
+    @Test("Expected offset is zero when the target precedes the timeline start")
+    func expectedOffsetBeforeTimelineStart() {
+        let offset = GuideScrollHelper.expectedScrollOffsetX(
+            timelineStart: makeDate(hour: 12, minute: 0),
+            scrollTarget: makeDate(hour: 9, minute: 30),
+            hourWidth: 100
+        )
+        #expect(offset == 0)
+    }
+
+    @Test("Expected offset scales with the hour column width")
+    func expectedOffsetScalesWithHourWidth() {
+        let calendar = Calendar.current
+        let midnight = calendar.startOfDay(for: Date())
+        let target = makeDate(hour: 2, minute: 0)
+        #expect(GuideScrollHelper.expectedScrollOffsetX(timelineStart: midnight, scrollTarget: target, hourWidth: 150) == 300)
+        #expect(GuideScrollHelper.expectedScrollOffsetX(timelineStart: midnight, scrollTarget: target, hourWidth: 300) == 600)
+    }
 }

--- a/NexusPVRTests/GuideViewModelTests.swift
+++ b/NexusPVRTests/GuideViewModelTests.swift
@@ -84,6 +84,40 @@ struct GuideViewModelTests {
         #endif
     }
 
+    // MARK: - Timeline anchoring (#140)
+
+    @Test("Catch-up timelines start at midnight, so the guide must scroll to reach now")
+    func catchupTimelineStartsAtMidnight() {
+        let vm = GuideViewModel()
+        vm.allowsPastDates = true
+        let midnight = Calendar.current.startOfDay(for: Date())
+        #expect(vm.timelineStart == midnight)
+
+        // The distance the guide has to travel to sit on the current
+        // half-hour — zero would mean no scroll is needed, which is exactly
+        // the assumption that left the guide at 00:00 (#140).
+        let target = GuideScrollHelper.calculateScrollTarget(currentTime: Date())
+        let offset = GuideScrollHelper.expectedScrollOffsetX(
+            timelineStart: vm.timelineStart,
+            scrollTarget: target,
+            hourWidth: 150
+        )
+        #expect(offset == CGFloat(target.timeIntervalSince(midnight) / 3600) * 150)
+    }
+
+    @Test("Without catch-up the timeline already starts at the current half-hour")
+    func regularTimelineStartsAtNow() {
+        let vm = GuideViewModel()
+        vm.allowsPastDates = false
+        let target = GuideScrollHelper.calculateScrollTarget(currentTime: Date())
+        #expect(vm.timelineStart == target)
+        #expect(GuideScrollHelper.expectedScrollOffsetX(
+            timelineStart: vm.timelineStart,
+            scrollTarget: target,
+            hourWidth: 150
+        ) == 0)
+    }
+
     @Test("previousDay moves backward from a future date")
     func previousDayMovesBack() {
         let vm = GuideViewModel()


### PR DESCRIPTION
Closes #140.

## Root cause

With catch-up enabled (`allowsPastDates == true`) the guide's timeline deliberately starts at midnight so earlier programmes stay reachable, and reaching "now" depends entirely on the initial `scrollTo`. That was a single request from `.onAppear` plus one fixed 0.4s retry — if either landed before the grid had laid out its rows, the request was silently dropped and the guide stayed parked at 00:00.

## Changes

- **`GuideView.startInitialScroll(using:)`** — runs the current-time positioning as a cancellable task, retrying up to 8 times (~2.3s) and stopping as soon as the observed `gridHorizontalOffset` confirms the scroll took effect. Re-triggered when rows land (`viewModel.channels.count`) and when `epgCache.isFullyLoaded` flips.
- The catch-up return path still wins: the task is skipped while a catch-up return target is pending (macOS) or `preservesGuidePositionAfterCatchup` is set.
- `.onDisappear` resets the guard, so reopening the guide re-anchors on now rather than regressing to 00:00.
- **`GuideScrollHelper.expectedScrollOffsetX(timelineStart:scrollTarget:hourWidth:)`** — supplies the distance the retry checks against. It returns 0 for NextPVR, whose timeline already begins at the current half-hour, so that build takes no scroll at all.
- tvOS anchors its own `guideStartTime` on the current half-hour and is untouched.

## Verification

Demo mode never reproduced the failure (its data loads in ~10ms), so the mechanism was verified with instrumented builds:

- Suppressing the scroll requests reproduces the reported state — the guide sits at offset 0, i.e. 00:00.
- Dropping only the first three attempts logs `attempt=0..2 offset=0.0` then `settled at attempt 3` at the expected 4950pt offset: the retry recovers exactly the failure mode.
- With the fix in place it settles on attempt 0, and a fresh install opens on the current time.

Tests: 4 new unit tests (timeline anchoring in `GuideViewModelTests`, offset math in `GuideScrollHelperTests`); 673 unit tests pass on both schemes; the full iOS UI suite passes; all six scheme/platform build combinations succeed.

## Note on UI coverage

The UI test target is wired to `TEST_TARGET_NAME = NextPVR` for both schemes, so UI tests always drive the NextPVR app and cannot exercise Dispatcharr-only guide behaviour. A UI test written for this bug passed even against a deliberately broken build for that reason, so it was dropped in favour of unit coverage. Adding a Dispatcharr-hosted UI test target would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V866Gw9eJGKdmVw2wBMn3j