### PR TITLE
Speed up guide scrolling with catch-up data (#141)

### DIFF
--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -34,7 +34,14 @@ final class EPGCache: ObservableObject {
     @Published private(set) var earliestEPGDate: Date?
 
     private(set) var channelMap: [Int: Channel] = [:]
-    private(set) var epg: [Int: [Program]] = [:]
+    private(set) var epg: [Int: [Program]] = [:] {
+        didSet { epgGeneration &+= 1 }
+    }
+    /// Bumped whenever `epg` is replaced or merged into. Views that memoize
+    /// derived slices of the EPG (see `GuideViewModel.programs(for:)`) key
+    /// their caches on this so a background merge or refresh invalidates them
+    /// without any explicit notification (#141).
+    private(set) var epgGeneration: Int = 0
     private var loadedDays: Set<String> = [] // "yyyy-MM-dd" keys
     private var backgroundLoadTask: Task<Void, Never>?
     private var isLoadInProgress = false

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -719,9 +719,55 @@ struct GuideView: View {
 
     #if !os(tvOS)
     @State private var scrollViewHeight: CGFloat = 0
+    @State private var scrollViewWidth: CGFloat = 0
+    /// Hour offsets from `timelineStart` currently worth rendering (#141).
+    /// `nil` until the scroll view reports its size — every program is drawn
+    /// until then, so the grid is never blank on first paint.
+    @State private var visibleHourWindow: ClosedRange<Int>?
     /// Guards the once-per-appearance current-time positioning (#140).
     @State private var hasCompletedInitialScroll = false
     @State private var initialScrollTask: Task<Void, Never>?
+
+    /// Recomputes which hour slots the grid should render, quantized to whole
+    /// hours with one hour of slack on each side (#141).
+    ///
+    /// Rows are positioned by offset inside a full-width ZStack, so nothing
+    /// vertical or horizontal shifts when the window narrows — the cells
+    /// outside it simply are not built. Quantizing matters: keying the filter
+    /// on the raw offset would rebuild every row on every scroll frame, which
+    /// costs more than it saves. This only changes state when the scroll
+    /// crosses an hour boundary.
+    private func updateVisibleHourWindow() {
+        guard scrollViewWidth > 0, hourWidth > 0 else { return }
+
+        // Content x of the timeline's first hour, past the channel column.
+        let timelineOriginX = channelWidth
+        let leadingHour = Int(floor((gridHorizontalOffset - timelineOriginX) / hourWidth)) - 1
+        let trailingHour = Int(ceil((gridHorizontalOffset + scrollViewWidth - timelineOriginX) / hourWidth)) + 1
+        let window = max(0, leadingHour)...max(0, trailingHour)
+
+        if visibleHourWindow != window {
+            visibleHourWindow = window
+        }
+    }
+
+    /// Narrows a row's programs to the ones intersecting the rendered window.
+    /// Cells are absolutely positioned, so dropping the rest changes nothing
+    /// about where the survivors land (#141).
+    private func renderedPrograms(from programs: [Program]) -> [Program] {
+        guard let window = visibleTimeWindow else { return programs }
+        return programs.filter { $0.endDate > window.start && $0.startDate < window.end }
+    }
+
+    /// The time span the grid is currently rendering, or `nil` for "everything".
+    private var visibleTimeWindow: (start: Date, end: Date)? {
+        guard let visibleHourWindow else { return nil }
+        let timelineStart = viewModel.timelineStart
+        return (
+            start: timelineStart.addingTimeInterval(Double(visibleHourWindow.lowerBound) * 3600),
+            end: timelineStart.addingTimeInterval(Double(visibleHourWindow.upperBound + 1) * 3600)
+        )
+    }
 
     /// Positions the timeline on the current half-hour when the guide appears.
     ///
@@ -831,15 +877,18 @@ struct GuideView: View {
             .refreshable {
                 await refreshGuide()
             }
-            .onScrollGeometryChange(for: CGFloat.self) { geo in
-                geo.containerSize.height
+            .onScrollGeometryChange(for: CGSize.self) { geo in
+                geo.containerSize
             } action: { _, new in
-                scrollViewHeight = new
+                scrollViewHeight = new.height
+                scrollViewWidth = new.width
+                updateVisibleHourWindow()
             }
             .onScrollGeometryChange(for: CGFloat.self) { geo in
                 geo.contentOffset.x
             } action: { _, new in
                 gridHorizontalOffset = new
+                updateVisibleHourWindow()
             }
             #if os(iOS)
             .onScrollGeometryChange(for: CGFloat.self) { geo in
@@ -1790,16 +1839,25 @@ struct GuideView: View {
 
     private func programsRow(_ channel: Channel) -> some View {
         let timelineStart = viewModel.timelineStart
-        let programs = viewModel.visiblePrograms(for: channel)
-        // Calculate scroll target: :00 or :30 based on current minute
-        let scrollTarget = GuideScrollHelper.calculateScrollTarget(currentTime: Date())
+        let dayPrograms = viewModel.visiblePrograms(for: channel)
+        #if os(tvOS)
+        let programs = dayPrograms
+        #else
+        // Only build the cells the viewer can actually see (#141).
+        let programs = renderedPrograms(from: dayPrograms)
+        #endif
+        // Scroll target: :00 or :30 based on current minute
+        let scrollTarget = viewModel.scrollTargetTime
 
         return ZStack(alignment: .leading) {
             // Background for the full timeline
             Color.clear
                 .frame(width: hourWidth * CGFloat(viewModel.hoursToShow.count))
 
-            if programs.isEmpty {
+            // Keyed off the whole day, not the rendered window, so scrolling
+            // into an empty stretch of a populated row doesn't swap in the
+            // channel-name placeholder.
+            if dayPrograms.isEmpty {
                 // Show channel name as placeholder so user can still tap to play
                 Button {
                     playLiveChannel(channel)
@@ -1821,11 +1879,7 @@ struct GuideView: View {
                 let matchesKeywords = viewModel.keywordMatchedProgramIds.contains(program.id)
                 let sport = viewModel.detectedSport(for: program)
                 #if DISPATCHERPVR
-                let catchupAvailable = CatchupAvailability.isAvailable(
-                    program: program,
-                    channelIsCatchup: channel.isCatchup,
-                    catchupDays: channel.catchupDays
-                )
+                let catchupAvailable = viewModel.isCatchupAvailable(program, on: channel)
                 #else
                 let catchupAvailable = false
                 #endif

--- a/NexusPVR/Features/Guide/GuideViewModel.swift
+++ b/NexusPVR/Features/Guide/GuideViewModel.swift
@@ -55,23 +55,107 @@ final class GuideViewModel: ObservableObject {
     // Cached sport detection results (avoids re-running regex per render)
     private var sportCache: [Int: Sport?] = [:]
 
+    // Cached per-channel programs for the selected day (#141)
+    private var programsCache: [Int: [Program]] = [:]
+    private var programsCacheDayStart: Date?
+    private var programsCacheGeneration: Int?
+
+    // Cached catch-up availability per program (#141) — the underlying check
+    // walks the calendar, and the guide asked it once per cell per pass.
+    private var catchupAvailabilityCache: [Int: Bool] = [:]
+    private var catchupAvailabilityBucket: Int?
+
     // Keyword-matched program IDs (O(1) lookup per cell)
     @Published private(set) var keywordMatchedProgramIds: Set<Int> = []
 
     // Reference to EPGCache (set during loadData)
     weak var epgCache: EPGCache?
 
-    var timelineStart: Date {
+    /// Memoized timeline geometry (#141).
+    ///
+    /// `timelineStart` / `hoursToShow` / `hourSlotCount` are read once per
+    /// program cell during a guide pass, and each recomputation walked the
+    /// calendar 24 times. They only actually change when the selected day, the
+    /// past-dates flag, or the current half-hour changes — so they are
+    /// computed once per those inputs and served from here afterwards.
+    /// Validity is checked with plain `Date` comparisons and one integer
+    /// division, no calendar arithmetic.
+    private struct TimelineGeometry {
+        let dayStart: Date
+        let dayEnd: Date
+        let allowsPastDates: Bool
+        let halfHourBucket: Int
+        let start: Date
+        let hours: [Date]
+
+        func isValid(for date: Date, allowsPastDates: Bool, bucket: Int) -> Bool {
+            self.allowsPastDates == allowsPastDates
+                && self.halfHourBucket == bucket
+                && date >= dayStart
+                && date < dayEnd
+        }
+    }
+
+    private var timelineGeometry: TimelineGeometry?
+    private var cachedScrollTarget: Date?
+    private var cachedScrollTargetBucket: Int?
+
+    private static func halfHourBucket(for now: Date) -> Int {
+        Int(now.timeIntervalSince1970 / 1800)
+    }
+
+    private func geometry(now: Date = Date()) -> TimelineGeometry {
+        let bucket = Self.halfHourBucket(for: now)
+        if let cached = timelineGeometry,
+           cached.isValid(for: selectedDate, allowsPastDates: allowsPastDates, bucket: bucket) {
+            return cached
+        }
+
         let calendar = Calendar.current
-        if isOnToday && !allowsPastDates {
+        let dayStart = calendar.startOfDay(for: selectedDate)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart.addingTimeInterval(24 * 3600)
+        let isToday = calendar.isDate(selectedDate, inSameDayAs: now)
+
+        let start: Date
+        if isToday && !allowsPastDates {
             // Start from current half-hour (round down to :00 or :30)
-            let now = Date()
             let minute = calendar.component(.minute, from: now)
             let roundedMinute = minute >= 30 ? 30 : 0
-            return calendar.date(bySettingHour: calendar.component(.hour, from: now),
-                                minute: roundedMinute, second: 0, of: now) ?? now
+            start = calendar.date(bySettingHour: calendar.component(.hour, from: now),
+                                  minute: roundedMinute, second: 0, of: now) ?? now
+        } else {
+            start = dayStart
         }
-        return calendar.startOfDay(for: selectedDate)
+
+        let count = Self.hourCount(for: selectedDate, now: now, includesPastHours: allowsPastDates)
+        var hours: [Date] = []
+        hours.reserveCapacity(count)
+        var current = start
+        for _ in 0..<count {
+            hours.append(current)
+            current = calendar.date(byAdding: .hour, value: 1, to: current) ?? current
+        }
+
+        let geometry = TimelineGeometry(
+            dayStart: dayStart,
+            dayEnd: dayEnd,
+            allowsPastDates: allowsPastDates,
+            halfHourBucket: bucket,
+            start: start,
+            hours: hours
+        )
+        timelineGeometry = geometry
+        return geometry
+    }
+
+    var timelineStart: Date {
+        geometry().start
+    }
+
+    /// Number of hour slots in the rendered timeline, without rebuilding the
+    /// hour array to count it.
+    var hourSlotCount: Int {
+        geometry().hours.count
     }
 
     var hasActiveFilters: Bool {
@@ -117,21 +201,42 @@ final class GuideViewModel: ObservableObject {
     }
 
     var hoursToShow: [Date] {
-        var hours: [Date] = []
-        let calendar = Calendar.current
-        var current = timelineStart
-        let count = Self.hourCount(
-            for: selectedDate,
-            now: Date(),
-            includesPastHours: allowsPastDates
-        )
-
-        for _ in 0..<count {
-            hours.append(current)
-            current = calendar.date(byAdding: .hour, value: 1, to: current) ?? current
-        }
-        return hours
+        geometry().hours
     }
+
+    /// The half-hour the guide scrolls to and aligns live cell text against,
+    /// memoized per half-hour bucket (#141) — it was recomputed per row.
+    var scrollTargetTime: Date {
+        let bucket = Self.halfHourBucket(for: Date())
+        if let cached = cachedScrollTarget, cachedScrollTargetBucket == bucket {
+            return cached
+        }
+        let target = GuideScrollHelper.calculateScrollTarget(currentTime: Date())
+        cachedScrollTarget = target
+        cachedScrollTargetBucket = bucket
+        return target
+    }
+
+    #if DISPATCHERPVR
+    /// Whether `program` can be played back via catch-up, memoized per program
+    /// for the current half-hour (#141). The window slides with `now`, so the
+    /// cache is dropped whenever the half-hour bucket changes.
+    func isCatchupAvailable(_ program: Program, on channel: Channel) -> Bool {
+        let bucket = Self.halfHourBucket(for: Date())
+        if catchupAvailabilityBucket != bucket {
+            catchupAvailabilityCache = [:]
+            catchupAvailabilityBucket = bucket
+        }
+        if let cached = catchupAvailabilityCache[program.id] { return cached }
+        let available = CatchupAvailability.isAvailable(
+            program: program,
+            channelIsCatchup: channel.isCatchup,
+            catchupDays: channel.catchupDays
+        )
+        catchupAvailabilityCache[program.id] = available
+        return available
+    }
+    #endif
 
     /// Returns cached sport detection result for a program
     func detectedSport(for program: Program) -> Sport? {
@@ -237,8 +342,7 @@ final class GuideViewModel: ObservableObject {
     /// preserves earlier programs when catch-up expands today's timeline to
     /// midnight, while keeping the existing future-only behavior elsewhere.
     func visiblePrograms(for channel: Channel) -> [Program] {
-        guard let cache = epgCache else { return [] }
-        let programs = cache.programs(for: channel.id, on: selectedDate)
+        let programs = programsOnSelectedDate(for: channel)
         if isOnToday {
             // Show any program that overlaps the visible timeline (ends after timeline start)
             let start = timelineStart
@@ -247,9 +351,32 @@ final class GuideViewModel: ObservableObject {
         return programs
     }
 
+    /// The selected day's programs for a channel, memoized (#141).
+    ///
+    /// `EPGCache.programs(for:on:)` scans the channel's whole multi-day array
+    /// and does calendar work to bound the day; the guide asked for it once per
+    /// row per pass. The cache is keyed on the selected day plus the cache's
+    /// `epgGeneration`, so a background merge or a refresh drops it.
+    private func programsOnSelectedDate(for channel: Channel) -> [Program] {
+        guard let cache = epgCache else { return [] }
+        let geometry = geometry()
+        let generation = cache.epgGeneration
+
+        if programsCacheDayStart != geometry.dayStart || programsCacheGeneration != generation {
+            programsCache = [:]
+            programsCacheDayStart = geometry.dayStart
+            programsCacheGeneration = generation
+        }
+
+        if let cached = programsCache[channel.id] { return cached }
+        let programs = cache.programs(for: channel.id, on: selectedDate)
+        programsCache[channel.id] = programs
+        return programs
+    }
+
     func programWidth(for program: Program, hourWidth: CGFloat, startTime: Date) -> CGFloat {
         let visibleStart = max(program.startDate, startTime)
-        let timelineEnd = startTime.addingTimeInterval(Double(hoursToShow.count) * 3600)
+        let timelineEnd = startTime.addingTimeInterval(Double(hourSlotCount) * 3600)
         let visibleEnd = min(program.endDate, timelineEnd)
         let duration = visibleEnd.timeIntervalSince(visibleStart)
         return max(CGFloat(duration / 3600) * hourWidth, 50)

--- a/NexusPVRTests/EPGCacheTests.swift
+++ b/NexusPVRTests/EPGCacheTests.swift
@@ -54,6 +54,19 @@ struct EPGCacheTests {
         #expect(cache.isFullyLoaded == false)
     }
 
+    // MARK: - EPG generation (#141)
+
+    @Test("epgGeneration starts at zero and advances when the EPG is replaced")
+    func epgGenerationAdvancesOnMutation() {
+        let cache = EPGCache()
+        #expect(cache.epgGeneration == 0)
+
+        // invalidate() reassigns `epg`, which is what consumers key their
+        // memoized slices on.
+        cache.invalidate()
+        #expect(cache.epgGeneration > 0)
+    }
+
     // MARK: - Refresh
 
     @Test("refresh keeps cached data when the server is not configured")

--- a/NexusPVRTests/GuideViewModelTests.swift
+++ b/NexusPVRTests/GuideViewModelTests.swift
@@ -206,6 +206,61 @@ struct GuideViewModelTests {
         #expect(Calendar.current.component(.hour, from: vm.hoursToShow[0]) == 0)
     }
 
+    // MARK: - Memoized timeline geometry (#141)
+
+    @Test("Repeated timeline reads return identical geometry")
+    func timelineGeometryIsStableAcrossReads() {
+        let vm = GuideViewModel()
+        vm.allowsPastDates = true
+        #expect(vm.timelineStart == vm.timelineStart)
+        #expect(vm.hoursToShow == vm.hoursToShow)
+        #expect(vm.hourSlotCount == vm.hoursToShow.count)
+    }
+
+    @Test("Changing the selected day recomputes the memoized timeline")
+    func timelineGeometryFollowsSelectedDate() {
+        let vm = GuideViewModel()
+        vm.allowsPastDates = true
+        #expect(Calendar.current.isDateInToday(vm.timelineStart))
+
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        vm.selectedDate = tomorrow
+        #expect(vm.timelineStart == Calendar.current.startOfDay(for: tomorrow))
+        #expect(vm.hoursToShow.first == Calendar.current.startOfDay(for: tomorrow))
+        #expect(vm.hourSlotCount == 24)
+    }
+
+    @Test("Changing allowsPastDates recomputes the memoized timeline")
+    func timelineGeometryFollowsPastDatesFlag() {
+        let vm = GuideViewModel()
+        vm.allowsPastDates = true
+        #expect(vm.timelineStart == Calendar.current.startOfDay(for: Date()))
+
+        vm.allowsPastDates = false
+        let minute = Calendar.current.component(.minute, from: vm.timelineStart)
+        #expect(minute == 0 || minute == 30)
+        #expect(vm.timelineStart > Calendar.current.startOfDay(for: Date()) || minute == 0)
+    }
+
+    @Test("scrollTargetTime matches the helper and is stable across reads")
+    func scrollTargetTimeIsMemoized() {
+        let vm = GuideViewModel()
+        let expected = GuideScrollHelper.calculateScrollTarget(currentTime: Date())
+        #expect(vm.scrollTargetTime == expected)
+        #expect(vm.scrollTargetTime == vm.scrollTargetTime)
+    }
+
+    @Test("hourSlotCount matches hourCount for the selected date")
+    func hourSlotCountMatchesHourCount() {
+        let vm = GuideViewModel()
+        vm.allowsPastDates = true
+        #expect(vm.hourSlotCount == GuideViewModel.hourCount(for: vm.selectedDate, includesPastHours: true))
+
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        vm.selectedDate = tomorrow
+        #expect(vm.hourSlotCount == GuideViewModel.hourCount(for: tomorrow, includesPastHours: true))
+    }
+
     // MARK: - hourCount
 
     @Test("hourCount enforces minimum 6 hours even late at night")

--- a/NexusPVRUITests/NexusPVRUITests.swift
+++ b/NexusPVRUITests/NexusPVRUITests.swift
@@ -52,6 +52,52 @@ final class NexusPVRUITests: XCTestCase {
     }
 
     #if os(iOS)
+    /// The grid only builds the programme cells inside the visible time
+    /// window (#141), so scrolling must keep filling it — horizontally as the
+    /// window moves along the timeline, and vertically as rows are realized.
+    @MainActor
+    func testGuideKeepsRenderingProgramsWhileScrolling() throws {
+        let app = launchApp()
+        navigateToTab("Guide", app: app)
+        XCTAssertTrue(waitForGuideContent(in: app), "Guide content should be loaded")
+
+        let grid = app.scrollViews["guide-view"].firstMatch
+        let programCells = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'guide-program-'"))
+        XCTAssertTrue(waitForCondition(timeout: 8) { programCells.count > 0 }, "Guide should render programme cells")
+
+        guard grid.waitForExistence(timeout: 5) else {
+            throw XCTSkip("Guide scroll view is not exposed on this platform")
+        }
+
+        // Forward along the timeline, then back to where we started.
+        for _ in 0..<3 {
+            grid.swipeLeft()
+            pause(0.4)
+            XCTAssertTrue(
+                waitForCondition(timeout: 4) { programCells.count > 0 },
+                "Programme cells should keep rendering while scrolling forward"
+            )
+        }
+
+        grid.swipeDown()
+        pause(0.4)
+        XCTAssertTrue(
+            waitForCondition(timeout: 4) { programCells.count > 0 },
+            "Programme cells should keep rendering while scrolling vertically"
+        )
+
+        for _ in 0..<3 {
+            grid.swipeRight()
+            pause(0.4)
+        }
+        XCTAssertTrue(
+            waitForCondition(timeout: 4) { programCells.count > 0 },
+            "Programme cells should keep rendering after scrolling back"
+        )
+    }
+    #endif
+
+    #if os(iOS)
     /// A currently airing program offers `Watch Live`, and the catch-up
     /// restart action (#143) is a separate control — never the same button.
     /// Demo/NextPVR data has no catch-up channels, so the restart action is


### PR DESCRIPTION
Closes #141.

Catch-up triples the rendered timeline — 24 hours from midnight instead of the hours remaining today (`GuideViewModel.hourCount`) — and the grid was only lazy vertically. Every realized row built every programme of the day, and each cell re-derived timeline geometry that walks the calendar.

## 1. Memoized timeline geometry

`timelineStart` / `hoursToShow` / the new `hourSlotCount` are computed once per (selected day, `allowsPastDates`, current half-hour) and served from a cached `TimelineGeometry`; validity is a few `Date` comparisons and one integer division, no calendar arithmetic.

A 10,000-read benchmark on the iPhone 17 Pro simulator: **67.0ms → 3.3ms** (6.7µs → 0.33µs per read). That read happened once per programme cell via `programWidth`, plus twice per row — roughly 2.6ms per pass of pure calendar work on a 15-row screen of catch-up data.

`scrollTargetTime` (was per row) and `isCatchupAvailable(_:on:)` (was a calendar walk per cell) are memoized the same way, keyed on the half-hour bucket so they still slide with the clock.

## 2. Memoized day slices

`EPGCache` bumps an `epgGeneration` counter whenever `epg` changes, and `GuideViewModel` caches each channel's day slice keyed on (day, generation). `EPGCache.programs(for:on:)` scans the channel's entire multi-day array and did so once per row per pass; it now runs once per channel, and a background merge or refresh invalidates the cache with no explicit signalling.

## 3. Horizontal windowing

`programsRow` renders only the programmes overlapping the visible time window, derived from `gridHorizontalOffset` + container width and **quantized to whole hours with one hour of slack on each side** — keying the filter on the raw offset would rebuild every row on every scroll frame and cost more than it saves.

Cells are absolutely positioned inside a full-width `ZStack`, so the survivors land exactly where they did before; the timeline extent, the #140 scroll anchors, and the now-indicator are untouched. The empty-row placeholder keys off the whole day rather than the window, so scrolling into a gap doesn't swap in the channel-name button. Each skipped cell also skips its `ProgramCell` and its `.contextMenu`.

Measured on the Dispatcharr demo build with instrumented logging: **rows drop from 14–40 built cells to 5–10** at the current window.

tvOS already windowed to its visible span (`tvOSVisiblePrograms`) and is untouched.

## Verification

- All six scheme/platform build combinations succeed.
- 681 unit tests pass on both schemes — 7 new: timeline memoization (stability, day-change and flag-change invalidation, `hourSlotCount` agreement with `hourCount`), `scrollTargetTime`, and `epgGeneration` advancement.
- New UI test `testGuideKeepsRenderingProgramsWhileScrolling` swipes the grid forward, vertically, and back, asserting cells keep rendering — it would catch a window computed with the wrong origin or sign. Full iOS UI suite passes.
- Visual check on the Dispatcharr demo build: opens on the current time with the now-indicator in place, cells render correctly. Confirmed noticeably smoother on macOS.

Caveat on coverage: the UI test target hosts the NextPVR app for both schemes, so the scrolling test exercises the shared windowing code against an 8-hour timeline rather than the 24-hour catch-up one. The catch-up-specific evidence is the instrumented cell counts and the visual check.
