### PR TITLE
Fix growing "behind live" drift on long NextPVR live sessions (#148)

### DIFF
--- a/NexusPVR/Features/Player/LivePositionTracker.swift
+++ b/NexusPVR/Features/Player/LivePositionTracker.swift
@@ -1,0 +1,72 @@
+//
+//  LivePositionTracker.swift
+//  PVR Client
+//
+//  Keeps the live timeshift position on the same clock as the server-side
+//  buffer (issue #148).
+//
+
+import Foundation
+
+/// Where playback sits inside NextPVR's timeshift buffer, in seconds from the
+/// start of the buffer.
+///
+/// mpv's `time-pos` can't be used as that clock directly. It is derived from the
+/// broadcast's MPEG-TS timestamps, so it restarts or jumps at a PTS
+/// discontinuity and wraps on a long enough session, and it also drops back to
+/// ~0 whenever the stream is reopened — which the live seek path does on every
+/// skip, and mpv's own recovery does on an EOF. Adding a fixed base offset to it
+/// therefore drifts away from the server's `stream_duration` origin: the UI ends
+/// up claiming an hour behind live while playback is still near the edge, and
+/// the next skip-forward, seeking relative to that bogus position, reopens the
+/// stream near the start of the buffer (#148).
+///
+/// So this integrates *increments* of `time-pos` rather than trusting its
+/// origin. Increments that can't be real playback — negative ones from a reload
+/// or discontinuity, or ones larger than the wall-clock time that has actually
+/// passed — are discarded, and the position is re-anchored explicitly whenever a
+/// seek puts it at a known place in the buffer. Worst case a discontinuity costs
+/// one poll interval of position, instead of desynchronising the clock for the
+/// rest of the session.
+nonisolated struct LivePositionTracker: Equatable {
+    /// Slack on the wall-clock bound. Live playback runs at 1x, but samples
+    /// arrive on a timer and mpv plays a short catch-up burst after a rebuffer,
+    /// so an increment slightly ahead of elapsed time is still genuine.
+    static let driftTolerance: Double = 1
+
+    /// Buffer position of the current playback point, seconds from buffer start.
+    private(set) var position: Double = 0
+
+    private var lastSample: Double?
+    private var lastSampleAt: Date?
+
+    init(position: Double = 0) {
+        self.position = max(0, position)
+    }
+
+    /// Re-anchors at a known buffer position — a completed live seek. The next
+    /// sample only re-arms the increment baseline, since mpv's position in the
+    /// reopened stream has a new origin.
+    mutating func anchor(at position: Double) {
+        self.position = max(0, position)
+        lastSample = nil
+        lastSampleAt = nil
+    }
+
+    /// Feeds one mpv `time-pos` sample.
+    mutating func update(playerPosition: Double, now: Date = Date()) {
+        defer {
+            lastSample = playerPosition
+            lastSampleAt = now
+        }
+        guard let lastSample, let lastSampleAt else { return }
+
+        let delta = playerPosition - lastSample
+        // Paused or stalled (0), or a reload/discontinuity moved the origin
+        // (negative) — either way no playback time can be credited.
+        guard delta > 0 else { return }
+
+        let elapsed = max(0, now.timeIntervalSince(lastSampleAt))
+        position += min(delta, elapsed + Self.driftTolerance)
+    }
+}

--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -86,9 +86,10 @@ struct PlayerView: View {
     /// extrapolated between polls (the buffer grows in real time).
     @State private var liveStreamInfo: LiveStreamInfo?
     @State private var liveStreamInfoAt: Date = .distantPast
-    /// Buffer position (seconds from buffer start) that the current stream begins at.
-    /// Non-zero after a live seek, since reopening at a byte offset resets mpv to 0.
-    @State private var liveBaseOffset: Double = 0
+    /// Where playback sits inside the server-side buffer. Integrated from mpv's
+    /// position rather than read off it, since mpv's origin shifts under us —
+    /// see `LivePositionTracker` (#148).
+    @State private var liveTracker = LivePositionTracker()
     @State private var isLiveSeeking = false
     /// Target of skip presses not yet committed to a reload — see `seekLiveBy`.
     @State private var pendingLiveSeekTarget: Double?
@@ -705,6 +706,9 @@ struct PlayerView: View {
             if liveEdgeRetryCount > 0 && position > 2 {
                 liveEdgeRetryCount = 0
             }
+            if isLiveStream {
+                liveTracker.update(playerPosition: position)
+            }
             detectBuffering()
         }
         #if os(tvOS)
@@ -760,7 +764,7 @@ struct PlayerView: View {
     private func resetLiveTimeshiftState() {
         liveStreamInfo = nil
         liveStreamInfoAt = .distantPast
-        liveBaseOffset = 0
+        liveTracker = LivePositionTracker()
     }
 
     // MARK: - Live timeshift buffer
@@ -774,9 +778,10 @@ struct PlayerView: View {
     }
 
     /// Play position measured from the start of the buffer, not from the start of
-    /// the current stream — those differ once a seek has reopened at an offset.
+    /// the current stream — those differ once a seek has reopened at an offset,
+    /// and mpv's own origin can move mid-stream (#148).
     private var livePlayPosition: Double {
-        liveBaseOffset + max(0, currentPosition)
+        liveTracker.position
     }
 
     private var secondsBehindLive: Double {
@@ -810,7 +815,7 @@ struct PlayerView: View {
 
         // mpv restarts at 0 in the reopened stream, so the buffer position it maps
         // to has to be carried separately.
-        liveBaseOffset = target
+        liveTracker.anchor(at: target)
         currentPosition = 0
         isLiveSeeking = true
         lastLiveSeekAt = Date()

--- a/NexusPVRTests/LivePositionTrackerTests.swift
+++ b/NexusPVRTests/LivePositionTrackerTests.swift
@@ -1,0 +1,145 @@
+//
+//  LivePositionTrackerTests.swift
+//  NexusPVRTests
+//
+//  Tests for the live timeshift position clock (issue #148).
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct LivePositionTrackerTests {
+
+    /// Feeds one second of playback per sample, the way a healthy live stream
+    /// reports it.
+    private func play(
+        _ tracker: inout LivePositionTracker,
+        seconds: Int,
+        from playerPosition: Double,
+        at start: Date
+    ) -> (playerPosition: Double, now: Date) {
+        var playerPosition = playerPosition
+        var now = start
+        for _ in 0..<seconds {
+            playerPosition += 1
+            now = now.addingTimeInterval(1)
+            tracker.update(playerPosition: playerPosition, now: now)
+        }
+        return (playerPosition, now)
+    }
+
+    @Test("Steady playback advances the buffer position in real time")
+    func steadyPlaybackAccumulates() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        tracker.update(playerPosition: 0, now: start)
+        _ = play(&tracker, seconds: 300, from: 0, at: start)
+        #expect(tracker.position == 300)
+    }
+
+    @Test("A paused stream holds its position")
+    func pausedPlaybackHoldsPosition() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        tracker.update(playerPosition: 0, now: start)
+        let played = play(&tracker, seconds: 60, from: 0, at: start)
+
+        // mpv repeats the same time-pos while paused, wall clock keeps going.
+        var now = played.now
+        for _ in 0..<120 {
+            now = now.addingTimeInterval(1)
+            tracker.update(playerPosition: played.playerPosition, now: now)
+        }
+        #expect(tracker.position == 60)
+    }
+
+    @Test("mpv restarting its clock mid-stream costs one sample, not the session")
+    func discontinuityDoesNotDesynchronise() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        tracker.update(playerPosition: 0, now: start)
+        let first = play(&tracker, seconds: 600, from: 0, at: start)
+        #expect(tracker.position == 600)
+
+        // A PTS discontinuity (or an mpv-internal reopen) drops time-pos back to
+        // near zero. The old `base + time-pos` reading would have collapsed to ~0
+        // here; the tracker keeps the position it earned.
+        let after = play(&tracker, seconds: 600, from: 0, at: first.now)
+        #expect(tracker.position >= 1199 && tracker.position <= 1200)
+        #expect(after.playerPosition == 600)
+    }
+
+    @Test("A forward jump is capped at the wall-clock time that actually passed")
+    func forwardJumpIsCappedByWallClock() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        tracker.update(playerPosition: 0, now: start)
+        _ = play(&tracker, seconds: 60, from: 0, at: start)
+
+        // A 33-bit PTS rollover reports an enormous forward step across one tick.
+        tracker.update(playerPosition: 95_443, now: start.addingTimeInterval(61))
+        #expect(tracker.position <= 61 + LivePositionTracker.driftTolerance)
+    }
+
+    @Test("A live seek re-anchors the position at the requested buffer offset")
+    func seekAnchorsAtTarget() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        tracker.update(playerPosition: 0, now: start)
+        let played = play(&tracker, seconds: 120, from: 0, at: start)
+
+        // Reopening at a byte offset restarts mpv near zero.
+        tracker.anchor(at: 3_000)
+        #expect(tracker.position == 3_000)
+
+        var now = played.now
+        now = now.addingTimeInterval(1)
+        tracker.update(playerPosition: 0, now: now)
+        let resumed = play(&tracker, seconds: 30, from: 0, at: now)
+        #expect(tracker.position == 3_030)
+        #expect(resumed.playerPosition == 30)
+    }
+
+    /// The reported bug: after a long session the UI claimed roughly an hour
+    /// behind live while playback was near the edge, and skipping forward from
+    /// that position reopened the stream near the start of the buffer.
+    @Test("A long live session with origin resets stays near the live edge")
+    func longRunningSessionReportsAccurateDelay() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        tracker.update(playerPosition: 0, now: start)
+
+        // Two hours of playback, with mpv's clock restarting every 20 minutes.
+        var now = start
+        // Server-side stream_duration, growing in real time. Playback opened a
+        // few seconds after the buffer did, so it trails it by that much.
+        var buffer = 20.0
+        for _ in 0..<6 {
+            let segment = play(&tracker, seconds: 1_200, from: 0, at: now)
+            now = segment.now
+            buffer += 1_200
+            tracker.update(playerPosition: 0, now: now)  // origin reset
+        }
+
+        let behindLive = max(0, buffer - tracker.position)
+        // At most the handful of samples lost to the resets — nowhere near the
+        // tens of minutes reported in #148.
+        #expect(behindLive < 60)
+
+        // And a skip forward from there still moves toward the live edge.
+        let target = LiveTimeshift.clampedTarget(tracker.position + 30, bufferDuration: buffer)
+        #expect(target > tracker.position)
+        #expect(target <= buffer - LiveTimeshift.edgeMargin)
+    }
+
+    @Test("A stream that opens with a non-zero mpv clock still starts at the buffer start")
+    func nonZeroStartOriginIsIgnored() {
+        let start = Date()
+        var tracker = LivePositionTracker()
+        // Raw MPEG-TS often reports a large first timestamp.
+        tracker.update(playerPosition: 44_100, now: start)
+        _ = play(&tracker, seconds: 90, from: 44_100, at: start)
+        #expect(tracker.position == 90)
+    }
+}


### PR DESCRIPTION
Fixes #148.

## Root cause

The live timeshift position was read as `liveBaseOffset + mpv time-pos`, which assumes mpv's clock shares an origin with the server's `stream_duration`. On NextPVR's raw MPEG-TS that only holds while nothing disturbs mpv's clock: `time-pos` restarts or jumps at a PTS discontinuity, wraps on a long enough session, and drops back to ~0 whenever the stream is reopened — which the live seek path does on every skip, and mpv's own EOF recovery does on its own.

Once that happened, both reported symptoms follow:

- `secondsBehindLive = liveBufferDuration - livePlayPosition` reports tens of minutes behind while playback is still near the edge, and
- `seekLiveBy` bases its target on that same position, so a skip forward converts a far-too-small position into a far-too-small byte offset and reopens the stream near the start of the buffer.

## Fix

New `LivePositionTracker` (`NexusPVR/Features/Player/LivePositionTracker.swift`):

- integrates *increments* of `time-pos` instead of trusting its origin;
- discards increments that can't be real playback — negative ones (reload or discontinuity) and ones beyond the wall-clock time that actually passed, plus 1s of slack for polling jitter and post-rebuffer catch-up;
- is re-anchored explicitly by `seekLive(to:)` at the requested buffer offset, and reset with the rest of the timeshift state when a new stream starts (a PiP restore adopts the existing state, as before).

A discontinuity now costs one poll interval of position rather than desynchronising the clock for the rest of the session. `PlayerView` replaces `liveBaseOffset` with the tracker and feeds it from `.onChange(of: currentPosition)` for live streams only.

## Tests

`NexusPVRTests/LivePositionTrackerTests.swift` covers steady playback, pause, a mid-stream origin reset, a PTS-rollover forward jump, seek re-anchoring, a non-zero opening timestamp, and the regression case from the issue: a 2-hour session with mpv's clock restarting every 20 minutes stays under 60s behind live and still skips *forward* toward the live edge.

Verified: full `NexusPVRTests` suite on macOS (689 tests) passes; NextPVR/tvOS and Dispatcharr/iOS builds succeed.
