### PR TITLE
Continue catch-up playback past the initial live edge (#150)

### DIFF
--- a/NexusPVR/Core/Models/CatchupProgramContext.swift
+++ b/NexusPVR/Core/Models/CatchupProgramContext.swift
@@ -1,0 +1,28 @@
+//
+//  CatchupProgramContext.swift
+//  nextpvr-apple-client
+//
+//  What the player needs to keep a catch-up session going as the programme
+//  keeps airing (issue #150).
+//
+
+import Foundation
+
+/// The programme a catch-up session was minted for, carried alongside the
+/// session id so `PlayerView` can mint the next session in the chain when the
+/// current archive runs out — see `CatchupContinuation`.
+///
+/// The channel identifier is the Dispatcharr UUID, the same one
+/// `DispatcherClient.startCatchupSession` takes, because the numeric channel id
+/// isn't accepted by the catch-up API.
+nonisolated struct CatchupProgramContext: Equatable, Sendable {
+    let channelUuid: String
+    let programStart: Date
+    let programEnd: Date
+
+    init(channelUuid: String, programStart: Date, programEnd: Date) {
+        self.channelUuid = channelUuid
+        self.programStart = programStart
+        self.programEnd = programEnd
+    }
+}

--- a/NexusPVR/Features/Guide/ProgramDetailView.swift
+++ b/NexusPVR/Features/Guide/ProgramDetailView.swift
@@ -879,6 +879,11 @@ struct ProgramDetailView: View {
                     channelId: channel.id,
                     channelName: channel.name,
                     catchupSessionId: session.sessionId,
+                    catchupProgram: CatchupProgramContext(
+                        channelUuid: channelUuid,
+                        programStart: program.startDate,
+                        programEnd: program.endDate
+                    ),
                     catchupGuideReturnTime: catchupGuideReturnTime
                 )
                 dismiss()

--- a/NexusPVR/Features/Player/CatchupContinuation.swift
+++ b/NexusPVR/Features/Player/CatchupContinuation.swift
@@ -1,0 +1,83 @@
+//
+//  CatchupContinuation.swift
+//  nextpvr-apple-client
+//
+//  Pure decision math for keeping catch-up playback going past the live edge
+//  that existed when the session was minted (issue #150).
+//
+
+import Foundation
+
+/// A catch-up session's archive is cut at the live edge as it stood when the
+/// session was minted: `POST /api/catchup/sessions/` fixes `start`, and the
+/// upstream URL it builds carries the duration `now - start` baked in. For a
+/// programme that is still airing that edge is not the end of the show, so
+/// playback used to end roughly `now - start` seconds in (#150).
+///
+/// The fix is to mint a fresh session at the point playback reached and reload,
+/// which is what this enum decides. Each continuation covers exactly the wall
+/// clock that elapsed while the previous one played, so the viewer keeps a
+/// constant distance behind live and no interval is skipped.
+nonisolated enum CatchupContinuation {
+    /// Minting a session whose archive is only a few seconds long buys one
+    /// reload's worth of buffering for almost no content, so hold off until at
+    /// least this much unplayed programme has aired.
+    static let minimumLeadSeconds: Double = 20
+
+    /// A continuation that plays less than this before hitting EOF again hasn't
+    /// really advanced — count it towards giving up rather than looping.
+    static let minimumSessionProgressSeconds: Double = 3
+
+    /// How many consecutive short sessions to tolerate before letting playback
+    /// end normally. Guards against an EOF that isn't the archive edge at all
+    /// (a dead upstream, say) turning into an endless remint loop.
+    static let maxConsecutiveShortSessions = 3
+
+    enum Decision: Equatable {
+        /// The whole programme has been played — let playback end.
+        case finished
+        /// Mint a new session starting at this wall-clock instant.
+        case resume(start: Date)
+        /// Too little new programme has aired; re-decide after this delay.
+        case wait(seconds: Double)
+    }
+
+    /// - Parameters:
+    ///   - programStart: the programme's scheduled start, i.e. the `start` of
+    ///     the very first session in the chain.
+    ///   - programEnd: the programme's scheduled end.
+    ///   - playedSeconds: seconds of the programme played so far, summed across
+    ///     every session in the chain.
+    ///   - now: current wall clock.
+    static func decide(
+        programStart: Date,
+        programEnd: Date,
+        playedSeconds: Double,
+        now: Date = Date()
+    ) -> Decision {
+        // Playback reached this instant of the broadcast, so it is where the
+        // next session has to pick up.
+        let resumeStart = programStart.addingTimeInterval(max(0, playedSeconds))
+        // Past programmes end up here too: their archive runs well beyond the
+        // programme, so by the time it EOFs `resumeStart` is past `programEnd`
+        // and playback ends exactly as it did before (#150 acceptance).
+        guard resumeStart < programEnd else { return .finished }
+
+        let lead = now.timeIntervalSince(resumeStart)
+        guard lead >= minimumLeadSeconds else {
+            return .wait(seconds: minimumLeadSeconds - lead)
+        }
+        return .resume(start: resumeStart)
+    }
+
+    /// Whether the continuation chain has stopped making progress and should be
+    /// abandoned.
+    static func shouldGiveUp(consecutiveShortSessions: Int) -> Bool {
+        consecutiveShortSessions >= maxConsecutiveShortSessions
+    }
+
+    /// Whether a session that played `seconds` before EOF counts as progress.
+    static func isShortSession(playedSeconds: Double) -> Bool {
+        playedSeconds < minimumSessionProgressSeconds
+    }
+}

--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -37,6 +37,10 @@ struct PlayerView: View {
     /// the recording-style seek bar, not the live-edge one) and is revoked
     /// server-side on teardown — see `endCatchupSessionIfNeeded()`.
     let catchupSessionId: String?
+    /// The programme `catchupSessionId` was minted for (#150). Present for
+    /// Dispatcharr catch-up playback; lets the player mint the next session in
+    /// the chain when the archive ends while the programme is still airing.
+    let catchupProgram: CatchupProgramContext?
 
     // Injected dependencies (default to app singletons via Dependencies)
     private let activePlayerSession: any ActivePlayerSessionManaging
@@ -110,6 +114,20 @@ struct PlayerView: View {
     /// isRecordingInProgress-only and never applies to catch-up.
     @State private var isCatchupSeeking = false
     @State private var catchupSeekSafetyTask: Task<Void, Never>?
+    /// Seconds of the programme played by *earlier* catch-up sessions in this
+    /// continuation chain (#150). Stays 0 until the first remint, so every
+    /// display and seek expression below is unchanged for a single-session
+    /// playback.
+    @State private var catchupPlayedOffset: Double = 0
+    /// The session currently feeding the player. Diverges from
+    /// `catchupSessionId` after the first continuation remint.
+    @State private var activeCatchupSessionId: String?
+    @State private var catchupContinuationTask: Task<Void, Never>?
+    @State private var isContinuingCatchup = false
+    @State private var catchupShortSessionCount = 0
+    /// Set across a continuation reload: the replacement stream has its own PTS
+    /// base, so `startTimeOffset` has to be recaptured from it.
+    @State private var pendingCatchupRebase = false
     @State private var bufferingStallCount = 0
     #if DISPATCHERPVR
     @State private var dispatchProfileBadge: String?
@@ -138,6 +156,7 @@ struct PlayerView: View {
         isRecordingInProgress: Bool = false,
         recordingStartTime: Date? = nil,
         catchupSessionId: String? = nil,
+        catchupProgram: CatchupProgramContext? = nil,
         activePlayerSession: any ActivePlayerSessionManaging = Dependencies.activePlayerSession,
         networkEventLogger: any NetworkEventLogging = Dependencies.networkEventLogger,
         liveKeepalive: LiveStreamKeepalive = Dependencies.liveStreamKeepalive
@@ -149,6 +168,7 @@ struct PlayerView: View {
         self.isRecordingInProgress = isRecordingInProgress
         self.recordingStartTime = recordingStartTime
         self.catchupSessionId = catchupSessionId
+        self.catchupProgram = catchupProgram
         self.activePlayerSession = activePlayerSession
         self.networkEventLogger = networkEventLogger
         self.liveKeepalive = liveKeepalive
@@ -177,12 +197,7 @@ struct PlayerView: View {
                 activePlayerSession: activePlayerSession,
                 networkEventLogger: networkEventLogger,
                 onPlaybackEnded: {
-                    if recoverFromLiveEdgeEOF() { return }
-                    savePlaybackPosition()
-                    markAsWatched()
-                    if !isRecordingInProgress {
-                        appState.stopPlayback()
-                    }
+                    handlePlaybackEnded()
                 },
                 onPlaybackRestarted: {
                     endCatchupSeekIndicator()
@@ -279,12 +294,7 @@ struct PlayerView: View {
                 activePlayerSession: activePlayerSession,
                 networkEventLogger: networkEventLogger,
                 onPlaybackEnded: {
-                    if recoverFromLiveEdgeEOF() { return }
-                    savePlaybackPosition()
-                    markAsWatched()
-                    if !isRecordingInProgress {
-                        appState.stopPlayback()
-                    }
+                    handlePlaybackEnded()
                 },
                 onPlaybackRestarted: {
                     endCatchupSeekIndicator()
@@ -338,12 +348,7 @@ struct PlayerView: View {
                 streamHeaders: client.streamAuthHeaders(),
                 networkEventLogger: networkEventLogger,
                 onPlaybackEnded: {
-                    if recoverFromLiveEdgeEOF() { return }
-                    savePlaybackPosition()
-                    markAsWatched()
-                    if !isRecordingInProgress {
-                        appState.stopPlayback()
-                    }
+                    handlePlaybackEnded()
                 },
                 onPlaybackRestarted: {
                     endCatchupSeekIndicator()
@@ -645,6 +650,8 @@ struct PlayerView: View {
             #endif
             catchupSeekSafetyTask?.cancel()
             catchupSeekSafetyTask = nil
+            catchupContinuationTask?.cancel()
+            catchupContinuationTask = nil
         }
         #if DISPATCHERPVR
         .onChange(of: appState.currentlyPlayingChannelName) { _ in
@@ -652,6 +659,12 @@ struct PlayerView: View {
         }
         #endif
         .onChange(of: duration) { _ in
+            // A continuation stream (#150) carries its own PTS base, so the
+            // display offset has to be recaptured the way the first load does.
+            if pendingCatchupRebase && duration > 0 {
+                pendingCatchupRebase = false
+                startTimeOffset = currentPosition > 1 ? currentPosition : 0
+            }
             // Resume playback position once duration is known (playback has started)
             if !hasResumed && duration > 0 {
                 hasResumed = true
@@ -899,10 +912,137 @@ struct PlayerView: View {
     /// (called just before this in `.onDisappear`) already clears the
     /// published copy.
     private func endCatchupSessionIfNeeded() {
-        guard let catchupSessionId else { return }
+        // After a continuation remint (#150) the session feeding the player is
+        // no longer the one this view was created with.
+        guard let sessionId = activeCatchupSessionId ?? catchupSessionId else { return }
         #if DISPATCHERPVR
-        Task { [client] in await client.endCatchupSession(catchupSessionId) }
+        Task { [client] in await client.endCatchupSession(sessionId) }
         #endif
+    }
+
+    /// Playback reached the end of the file mpv is reading. That means the
+    /// stream ended for a recording, but for live TV and for catch-up on a
+    /// programme that is still airing it only means the readable edge moved
+    /// ahead of us — both get a chance to recover before playback ends.
+    private func handlePlaybackEnded() {
+        if recoverFromLiveEdgeEOF() { return }
+        if continueCatchupIfNeeded() { return }
+        savePlaybackPosition()
+        markAsWatched()
+        if !isRecordingInProgress {
+            appState.stopPlayback()
+        }
+    }
+
+    /// Whether this EOF is the archive edge of a catch-up session for a
+    /// programme that is still airing — in which case a fresh session picks up
+    /// where this one stopped instead of playback ending (#150).
+    private func continueCatchupIfNeeded() -> Bool {
+        #if DISPATCHERPVR
+        guard let catchupProgram, catchupSessionId != nil else { return false }
+        // A single EOF surfaces twice (END_FILE plus the eof-reached property);
+        // the second one must not mint a second session.
+        guard !isContinuingCatchup else { return true }
+
+        let playedThisSession = max(0, currentPosition - startTimeOffset)
+        if CatchupContinuation.isShortSession(playedSeconds: playedThisSession) {
+            catchupShortSessionCount += 1
+        } else {
+            catchupShortSessionCount = 0
+        }
+        guard !CatchupContinuation.shouldGiveUp(consecutiveShortSessions: catchupShortSessionCount) else {
+            print("[Catchup] Ending playback: \(catchupShortSessionCount) continuations made no progress")
+            return false
+        }
+
+        let played = catchupPlayedOffset + playedThisSession
+        let decision = CatchupContinuation.decide(
+            programStart: catchupProgram.programStart,
+            programEnd: catchupProgram.programEnd,
+            playedSeconds: played,
+            now: Date()
+        )
+        guard decision != .finished else { return false }
+
+        isContinuingCatchup = true
+        startCatchupSeekIndicatorIfNeeded()
+        catchupContinuationTask?.cancel()
+        catchupContinuationTask = Task {
+            await continueCatchup(playedSeconds: played, context: catchupProgram)
+        }
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    #if DISPATCHERPVR
+    /// Mints the next session in the chain and reloads the player into it.
+    /// `playedSeconds` is where playback got to, measured from the programme's
+    /// scheduled start, which is exactly the `start` the new session needs.
+    private func continueCatchup(playedSeconds: Double, context: CatchupProgramContext) async {
+        defer { isContinuingCatchup = false }
+
+        while !Task.isCancelled {
+            switch CatchupContinuation.decide(
+                programStart: context.programStart,
+                programEnd: context.programEnd,
+                playedSeconds: playedSeconds,
+                now: Date()
+            ) {
+            case .finished:
+                endCatchupPlayback()
+                return
+
+            case .wait(let seconds):
+                // Playback has drawn level with the broadcast; let a little more
+                // of the programme air rather than mint a near-empty archive.
+                try? await Task.sleep(for: .seconds(seconds))
+
+            case .resume(let start):
+                do {
+                    let service = CatchupService(client: client, baseURL: client.baseURL)
+                    let session = try await service.startSession(
+                        channelUuid: context.channelUuid,
+                        startISO8601: ISO8601DateFormatter().string(from: start)
+                    )
+                    let url = try service.playbackURL(for: session)
+                    guard !Task.isCancelled, let reload = reloadURLFunc else { return }
+
+                    let previousSessionId = activeCatchupSessionId ?? catchupSessionId
+                    activeCatchupSessionId = session.sessionId
+                    // mpv restarts the new file at its own origin, so the part of
+                    // the programme already played has to be carried separately —
+                    // same shape as the live seek path's LivePositionTracker.
+                    catchupPlayedOffset = playedSeconds
+                    pendingCatchupRebase = true
+                    startTimeOffset = 0
+                    currentPosition = 0
+                    duration = 0
+                    reload(url)
+                    isPlaying = true
+                    print("[Catchup] Continuing at \(Int(playedSeconds))s into the programme")
+
+                    if let previousSessionId {
+                        Task { [client] in await client.endCatchupSession(previousSessionId) }
+                    }
+                } catch {
+                    print("[Catchup] Continuation failed: \(error.localizedDescription)")
+                    endCatchupPlayback()
+                }
+                return
+            }
+        }
+    }
+    #endif
+
+    /// Ends playback the way `handlePlaybackEnded` would have, once the
+    /// continuation chain decides there is nothing left to play.
+    private func endCatchupPlayback() {
+        endCatchupSeekIndicator()
+        savePlaybackPosition()
+        markAsWatched()
+        appState.stopPlayback()
     }
 
     /// Detects when playback has stalled (position not advancing while
@@ -1109,12 +1249,12 @@ struct PlayerView: View {
                         .onChanged { value in
                             isSeeking = true
                             let progress = max(0, min(1, value.location.x / geometry.size.width))
-                            seekPosition = progress * duration + startTimeOffset
+                            seekPosition = playerPosition(forDisplayed: progress * displayedDuration)
                             scheduleHideControls()
                         }
                         .onEnded { value in
                             let progress = max(0, min(1, value.location.x / geometry.size.width))
-                            let targetPosition = progress * duration + startTimeOffset
+                            let targetPosition = playerPosition(forDisplayed: progress * displayedDuration)
                             seekToPosition(targetPosition)
                             isSeeking = false
                         }
@@ -1125,14 +1265,14 @@ struct PlayerView: View {
 
             // Time labels
             HStack {
-                Text(formatTime((isSeeking ? seekPosition : currentPosition) - startTimeOffset))
+                Text(formatTime(displayedPosition))
                     .font(.caption)
                     .foregroundStyle(.white)
                     .monospacedDigit()
 
                 Spacer()
 
-                Text(formatTime(duration))
+                Text(formatTime(displayedDuration))
                     .font(.caption)
                     .foregroundStyle(.white)
                     .monospacedDigit()
@@ -1214,10 +1354,27 @@ struct PlayerView: View {
     }
 
     private func progressWidth(for totalWidth: CGFloat) -> CGFloat {
-        guard duration > 0 else { return 0 }
-        let adjPosition = (isSeeking ? seekPosition : currentPosition) - startTimeOffset
-        let progress = adjPosition / duration
+        guard displayedDuration > 0 else { return 0 }
+        let progress = displayedPosition / displayedDuration
         return max(0, min(totalWidth, CGFloat(progress) * totalWidth))
+    }
+
+    /// How far into the *programme* playback is, which after a catch-up
+    /// continuation (#150) is ahead of the current stream's own timeline.
+    /// Identical to the raw position while `catchupPlayedOffset` is 0.
+    private var displayedPosition: Double {
+        (isSeeking ? seekPosition : currentPosition) - startTimeOffset + catchupPlayedOffset
+    }
+
+    /// Length of the programme as far as it has been fetched: what the current
+    /// session holds, plus everything earlier sessions already played.
+    private var displayedDuration: Double {
+        duration + catchupPlayedOffset
+    }
+
+    /// Maps a point on the scrubber back onto the current stream's timeline.
+    private func playerPosition(forDisplayed displayed: Double) -> Double {
+        max(0, displayed - catchupPlayedOffset) + startTimeOffset
     }
 
     #if os(tvOS)

--- a/NexusPVR/Navigation/AppState.swift
+++ b/NexusPVR/Navigation/AppState.swift
@@ -64,6 +64,10 @@ final class AppState: ObservableObject {
     /// stream is archived playback rather than live/recording. Revoked by
     /// `PlayerView` on teardown — see `endCatchupSessionIfNeeded()`.
     @Published var currentlyPlayingCatchupSessionId: String?
+    /// The programme the current catch-up session was minted for (#150), so the
+    /// player can mint the next session in the chain when the archive runs out
+    /// while the programme is still airing.
+    @Published var currentlyPlayingCatchupProgram: CatchupProgramContext?
     /// Guide time that launched the current catch-up playback. Unlike the
     /// session id, this intentionally survives `stopPlayback()` long enough
     /// for a reconstructed macOS guide to consume and restore it.
@@ -500,6 +504,7 @@ final class AppState: ObservableObject {
         isRecordingInProgress: Bool = false,
         recordingStartTime: Date? = nil,
         catchupSessionId: String? = nil,
+        catchupProgram: CatchupProgramContext? = nil,
         catchupGuideReturnTime: Date? = nil
     ) {
         #if DEBUG
@@ -524,6 +529,7 @@ final class AppState: ObservableObject {
         currentlyPlayingIsRecordingInProgress = isRecordingInProgress
         currentlyPlayingRecordingStartTime = recordingStartTime
         currentlyPlayingCatchupSessionId = catchupSessionId
+        currentlyPlayingCatchupProgram = catchupProgram
         self.catchupGuideReturnTime = catchupGuideReturnTime
         isPreparingStream = false
         isShowingPlayer = true
@@ -554,6 +560,7 @@ final class AppState: ObservableObject {
         currentlyPlayingIsRecordingInProgress = false
         currentlyPlayingRecordingStartTime = nil
         currentlyPlayingCatchupSessionId = nil
+        currentlyPlayingCatchupProgram = nil
     }
 
     /// Clears the pending target only after the reconstructed macOS guide has

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -360,7 +360,8 @@ struct IOSNavigation: View {
                     resumePosition: appState.currentlyPlayingResumePosition,
                     isRecordingInProgress: appState.currentlyPlayingIsRecordingInProgress,
                     recordingStartTime: appState.currentlyPlayingRecordingStartTime,
-                    catchupSessionId: appState.currentlyPlayingCatchupSessionId
+                    catchupSessionId: appState.currentlyPlayingCatchupSessionId,
+                    catchupProgram: appState.currentlyPlayingCatchupProgram
                 )
                 .statusBarHidden()
             }
@@ -1274,7 +1275,8 @@ struct TVOSNavigation: View {
                     resumePosition: appState.currentlyPlayingResumePosition,
                     isRecordingInProgress: appState.currentlyPlayingIsRecordingInProgress,
                     recordingStartTime: appState.currentlyPlayingRecordingStartTime,
-                    catchupSessionId: appState.currentlyPlayingCatchupSessionId
+                    catchupSessionId: appState.currentlyPlayingCatchupSessionId,
+                    catchupProgram: appState.currentlyPlayingCatchupProgram
                 )
             }
         }
@@ -1952,7 +1954,8 @@ struct MacOSNavigation: View {
                     resumePosition: appState.currentlyPlayingResumePosition,
                     isRecordingInProgress: appState.currentlyPlayingIsRecordingInProgress,
                     recordingStartTime: appState.currentlyPlayingRecordingStartTime,
-                    catchupSessionId: appState.currentlyPlayingCatchupSessionId
+                    catchupSessionId: appState.currentlyPlayingCatchupSessionId,
+                    catchupProgram: appState.currentlyPlayingCatchupProgram
                 )
             } else {
                 // Show regular navigation with sidebar

--- a/NexusPVRTests/CatchupContinuationTests.swift
+++ b/NexusPVRTests/CatchupContinuationTests.swift
@@ -1,0 +1,239 @@
+//
+//  CatchupContinuationTests.swift
+//  NexusPVRTests
+//
+//  Coverage for keeping catch-up playback going past the live edge that
+//  existed when the session was minted (#150).
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct CatchupContinuationTests {
+    private let hour: TimeInterval = 3600
+
+    @Test("An airing programme resumes where playback stopped instead of ending")
+    func airingProgrammeResumes() {
+        let now = Date()
+        // Started 70 minutes ago and runs for two hours. Playback began 35
+        // minutes in, so the archive it was handed held 35 minutes — all of it
+        // played by now, 35 minutes later.
+        let start = now.addingTimeInterval(-70 * 60)
+        let end = start.addingTimeInterval(2 * hour)
+
+        let decision = CatchupContinuation.decide(
+            programStart: start,
+            programEnd: end,
+            playedSeconds: 35 * 60,
+            now: now
+        )
+
+        // Still 35 minutes of programme to fetch, not the end of the show.
+        #expect(decision == .resume(start: now.addingTimeInterval(-35 * 60)))
+    }
+
+    @Test("Each continuation covers exactly the wall clock the previous one played")
+    func continuationsLeaveNoGap() {
+        let programStart = Date()
+        let programEnd = programStart.addingTimeInterval(2 * hour)
+
+        // Session 1 was minted 35 minutes in and played all 35 minutes.
+        var played: Double = 35 * 60
+        var now = programStart.addingTimeInterval(played * 2)
+
+        guard case .resume(let firstResume) = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: played,
+            now: now
+        ) else {
+            Issue.record("expected a resume")
+            return
+        }
+        // Picks up exactly where the first archive stopped — no interval skipped.
+        #expect(firstResume == programStart.addingTimeInterval(35 * 60))
+
+        // That session holds firstResume → now, i.e. another 35 minutes, and
+        // playing it takes 35 more minutes of wall clock.
+        let secondLength = now.timeIntervalSince(firstResume)
+        played += secondLength
+        now = now.addingTimeInterval(secondLength)
+
+        guard case .resume(let secondResume) = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: played,
+            now: now
+        ) else {
+            Issue.record("expected a resume")
+            return
+        }
+        // Continuous with the end of the second archive, and still the same
+        // distance behind live as when playback started.
+        #expect(secondResume == firstResume.addingTimeInterval(secondLength))
+        #expect(now.timeIntervalSince(secondResume) == 35 * 60)
+    }
+
+    @Test("Playing the whole programme ends playback")
+    func fullyPlayedProgrammeFinishes() {
+        let programStart = Date().addingTimeInterval(-2 * hour)
+        let programEnd = programStart.addingTimeInterval(hour)
+
+        let decision = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: hour,
+            now: Date()
+        )
+
+        #expect(decision == .finished)
+    }
+
+    @Test("A past programme's archive overshoot ends playback as before")
+    func pastProgrammeKeepsExistingBehavior() {
+        let now = Date()
+        // Aired three hours ago; its archive runs from the programme start all
+        // the way to the live edge, so EOF arrives long past the programme end.
+        let programStart = now.addingTimeInterval(-3 * hour)
+        let programEnd = programStart.addingTimeInterval(hour)
+
+        let decision = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: 3 * hour,
+            now: now
+        )
+
+        #expect(decision == .finished)
+    }
+
+    @Test("Waits rather than minting an archive with nothing in it")
+    func waitsWhenLevelWithTheBroadcast() {
+        let now = Date()
+        let programStart = now.addingTimeInterval(-hour)
+        let programEnd = programStart.addingTimeInterval(2 * hour)
+
+        // Played to within 5 seconds of the broadcast.
+        let decision = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: hour - 5,
+            now: now
+        )
+
+        #expect(decision == .wait(seconds: CatchupContinuation.minimumLeadSeconds - 5))
+    }
+
+    @Test("Waiting long enough turns into a resume")
+    func waitThenResume() {
+        let programStart = Date().addingTimeInterval(-hour)
+        let programEnd = programStart.addingTimeInterval(2 * hour)
+        let played = hour - 5
+
+        guard case .wait(let seconds) = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: played,
+            now: programStart.addingTimeInterval(hour)
+        ) else {
+            Issue.record("expected a wait")
+            return
+        }
+
+        let decision = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: played,
+            now: programStart.addingTimeInterval(hour + seconds)
+        )
+        #expect(decision == .resume(start: programStart.addingTimeInterval(played)))
+    }
+
+    @Test("Exactly the minimum lead resumes without waiting")
+    func minimumLeadResumes() {
+        let now = Date()
+        let programStart = now.addingTimeInterval(-hour)
+        let programEnd = programStart.addingTimeInterval(2 * hour)
+        let played = hour - CatchupContinuation.minimumLeadSeconds
+
+        let decision = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: played,
+            now: now
+        )
+
+        #expect(decision == .resume(start: programStart.addingTimeInterval(played)))
+    }
+
+    @Test("Negative played time is treated as the programme start")
+    func negativePlayedClamps() {
+        let now = Date()
+        let programStart = now.addingTimeInterval(-hour)
+        let programEnd = now.addingTimeInterval(hour)
+
+        let decision = CatchupContinuation.decide(
+            programStart: programStart,
+            programEnd: programEnd,
+            playedSeconds: -30,
+            now: now
+        )
+
+        #expect(decision == .resume(start: programStart))
+    }
+
+    @Test("Sessions that play nothing are counted, and give up before looping")
+    func givesUpOnRepeatedShortSessions() {
+        #expect(CatchupContinuation.isShortSession(playedSeconds: 0))
+        #expect(CatchupContinuation.isShortSession(
+            playedSeconds: CatchupContinuation.minimumSessionProgressSeconds - 0.5
+        ))
+        #expect(!CatchupContinuation.isShortSession(playedSeconds: 30 * 60))
+
+        #expect(!CatchupContinuation.shouldGiveUp(consecutiveShortSessions: 0))
+        #expect(!CatchupContinuation.shouldGiveUp(
+            consecutiveShortSessions: CatchupContinuation.maxConsecutiveShortSessions - 1
+        ))
+        #expect(CatchupContinuation.shouldGiveUp(
+            consecutiveShortSessions: CatchupContinuation.maxConsecutiveShortSessions
+        ))
+    }
+
+    @Test("A programme's catch-up duration growing while it plays never ends it early")
+    func growingArchiveNeverEndsEarly() {
+        // Regression for #150: walk a full airing programme the way playback
+        // does — mint, play the archive dry, remint — and assert playback only
+        // finishes once the whole programme has been played.
+        let programStart = Date()
+        let programEnd = programStart.addingTimeInterval(hour)
+
+        var played: Double = 35 * 60           // archive at the first mint
+        var now = programStart.addingTimeInterval(played)
+        var reminted = 0
+
+        while true {
+            // Playing the current archive dry consumes that much wall clock.
+            now = programStart.addingTimeInterval(played * 2)
+            switch CatchupContinuation.decide(
+                programStart: programStart,
+                programEnd: programEnd,
+                playedSeconds: played,
+                now: now
+            ) {
+            case .finished:
+                #expect(played >= hour)         // the whole programme, not the initial edge
+                #expect(reminted > 0)
+                return
+            case .wait:
+                Issue.record("a viewer 35 minutes behind live never has to wait")
+                return
+            case .resume(let start):
+                #expect(start == programStart.addingTimeInterval(played))
+                reminted += 1
+                #expect(reminted < 10, "continuation is not converging")
+                played += now.timeIntervalSince(start)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #150.

## Cause

A catch-up session's archive is cut at the live edge **as it stood when the session was minted**: `POST /api/catchup/sessions/` fixes `start`, and the duration `now - start` is baked into the upstream URL it builds. Starting an airing programme from the beginning therefore played only the portion that had already aired and then exited — 35 minutes in, 35 minutes of playback — leaving a gap against `Watch Live`.

The EOF fell through both existing recovery paths: `shouldIgnoreEOFAsTransientLiveHLS` needs a non-seekable `.m3u8`, and `recoverFromLiveEdgeEOF` is live-stream only. So `onPlaybackEnded` ran `appState.stopPlayback()` and the player exited.

## Fix

At EOF, mint the next session in the chain starting at the instant playback reached, and reload into it. Each continuation covers exactly the wall clock the previous one played, so the viewer stays a constant distance behind live with no interval skipped, up to the programme's end.

- **`CatchupContinuation`** (new) — pure decision math: `finished` / `resume(start:)` / `wait(seconds:)`, plus the give-up rule for sessions that make no progress. A past programme's archive overruns its end, so by EOF the resume point is past `programEnd` and playback finishes exactly as before.
- **`CatchupProgramContext`** (new) — channel UUID and programme window, carried alongside the session id from `ProgramDetailView` through `AppState` and `NavigationRouter` into `PlayerView`.
- **`PlayerView`** — the three duplicated `onPlaybackEnded` closures collapse into `handlePlaybackEnded()`, which tries live-edge recovery, then the catch-up continuation, before ending playback. The continuation re-mints, reloads, revokes the superseded session and re-anchors `startTimeOffset` for the replacement stream's PTS base; teardown now revokes the *active* session rather than the original one.
- The seek bar keeps one programme-relative timeline across reminted sessions via `catchupPlayedOffset`, which stays 0 for any single-session playback.

## Acceptance criteria

- [x] Reaching the live edge that existed at session start no longer exits playback.
- [x] Playback continues as the catch-up feed grows, up to the programme's actual end.
- [x] No missing interval — each continuation starts exactly where the previous archive stopped.
- [x] Past-programme catch-up and normal live playback keep their existing behaviour (covered by tests).
- [x] Regression test for an airing programme whose catch-up duration grows while it plays.

## Verification

- `CatchupContinuationTests` — 10 new tests, including the requested regression that walks a full airing programme mint-by-mint.
- Full unit suite green on both schemes (699 tests each); Dispatcharr builds clean on macOS, iOS and tvOS.

## Known limitation

Scrubbing back before a continuation point clamps to that point, since the earlier session is gone. Seeking arbitrarily far back needs a remint-on-seek, which is larger than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129mu5w6fMqcdMGCYuBthvt