### PR TITLE
Honor anamorphic sample aspect in the PixelBuffer renderer (#152)

### DIFF
--- a/NexusPVR/Features/Player/MPVContainerView+macOS.swift
+++ b/NexusPVR/Features/Player/MPVContainerView+macOS.swift
@@ -294,11 +294,39 @@ final class MPVPlayerPixelBufferNSViewController: NSViewController, MPVPlayerMac
         displayLayer.videoGravity = .resizeAspect
         displayLayer.backgroundColor = NSColor.black.cgColor
         view.layer?.addSublayer(displayLayer)
+        // Fired on mpv's VO thread when the video format changes; the new
+        // aspect ratio only becomes readable at that point.
+        bridge?.onReconfig = { [weak self] _, _, _ in
+            self?.updateDisplayLayerGeometryOnMain()
+        }
     }
 
     override func viewDidLayout() {
         super.viewDidLayout()
-        bridge?.displayLayer.frame = view.bounds
+        updateDisplayLayerGeometry()
+    }
+
+    /// Callable from mpv's threads — the geometry update itself is main-thread only.
+    private nonisolated func updateDisplayLayerGeometryOnMain() {
+        MPVPlayerCore.scheduleOnMain { [weak self] in
+            self?.updateDisplayLayerGeometry()
+        }
+    }
+
+    /// The pixelbuffer VO delivers frames at the coded resolution with no
+    /// sample-aspect metadata, so anamorphic streams would render squeezed if
+    /// the layer simply fit the pixel grid. Size the layer to mpv's display
+    /// aspect and let the frames fill it instead (#152). Falls back to plain
+    /// aspect-fit while the aspect is still unknown.
+    private func updateDisplayLayerGeometry() {
+        guard let displayLayer = bridge?.displayLayer else { return }
+        if let aspect = player?.videoDisplayAspect {
+            displayLayer.videoGravity = .resize
+            displayLayer.frame = VideoAspectCorrection.fittedRect(displayAspect: aspect, in: view.bounds)
+        } else {
+            displayLayer.videoGravity = .resizeAspect
+            displayLayer.frame = view.bounds
+        }
     }
 
     func setup(errorBinding: Binding<String?>?, isRecordingInProgress: Bool = false, recordingStartTime: Date? = nil, preferKeyframeSeek: Bool = false) {
@@ -317,6 +345,9 @@ final class MPVPlayerPixelBufferNSViewController: NSViewController, MPVPlayerMac
             self?.onPlaybackRestarted?()
         }
         player?.onVideoInfoUpdate = { [weak self] codec, height, hwdec, audioChannels, dropped, gamma, fps in
+            // Safety net in case the aspect wasn't readable yet at reconfig
+            // time; this callback can arrive off the main thread.
+            self?.updateDisplayLayerGeometryOnMain()
             self?.onVideoInfoUpdate?(codec, height, hwdec, audioChannels, dropped, gamma, fps)
         }
     }

--- a/NexusPVR/Features/Player/MPVPlayerCore.swift
+++ b/NexusPVR/Features/Player/MPVPlayerCore.swift
@@ -519,6 +519,18 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
         return flag != 0
     }
 
+    /// Display aspect ratio (width / height) of the current video as reported
+    /// by mpv, which folds in the stream's sample aspect ratio. `nil` while no
+    /// video is loaded or the aspect is unknown. Used by the PixelBuffer
+    /// renderer, which receives frames stripped of aspect metadata (#152).
+    var videoDisplayAspect: Double? {
+        guard let mpv = mpv else { return nil }
+        var aspect: Double = 0
+        guard mpv_get_property(mpv, "video-params/aspect", MPV_FORMAT_DOUBLE, &aspect) >= 0,
+              aspect.isFinite, aspect > 0 else { return nil }
+        return aspect
+    }
+
     func getVideoInfo() -> (codec: String?, width: Int?, height: Int?, hwdec: String?, audioChannels: String?, droppedFrames: Int64, gamma: String?, fps: Double) {
         guard let mpv = mpv else { return (nil, nil, nil, nil, nil, 0, nil, 0) }
 

--- a/NexusPVR/Features/Player/MPVPlayerPixelBufferView.swift
+++ b/NexusPVR/Features/Player/MPVPlayerPixelBufferView.swift
@@ -60,8 +60,8 @@ class MPVPlayerPixelBufferView: UIView {
 
         let displayLayer = session.displayLayer
         displayLayer.backgroundColor = UIColor.black.cgColor
-        displayLayer.frame = bounds
         layer.addSublayer(displayLayer)
+        updateDisplayLayerGeometry()
 
         #if os(tvOS)
         for direction: UISwipeGestureRecognizer.Direction in [.left, .right, .up, .down] {
@@ -77,7 +77,30 @@ class MPVPlayerPixelBufferView: UIView {
         if session.displayLayer.superlayer !== layer {
             layer.addSublayer(session.displayLayer)
         }
-        session.displayLayer.frame = bounds
+        updateDisplayLayerGeometry()
+    }
+
+    /// Callable from mpv's threads — the geometry update itself is main-thread only.
+    private nonisolated func updateDisplayLayerGeometryOnMain() {
+        MPVPlayerCore.scheduleOnMain { [weak self] in
+            self?.updateDisplayLayerGeometry()
+        }
+    }
+
+    /// The pixelbuffer VO delivers frames at the coded resolution with no
+    /// sample-aspect metadata, so anamorphic streams would render squeezed if
+    /// the layer simply fit the pixel grid. Size the layer to mpv's display
+    /// aspect and let the frames fill it instead (#152). Falls back to plain
+    /// aspect-fit while the aspect is still unknown.
+    private func updateDisplayLayerGeometry() {
+        let displayLayer = session.displayLayer
+        if let aspect = session.player?.videoDisplayAspect {
+            displayLayer.videoGravity = .resize
+            displayLayer.frame = VideoAspectCorrection.fittedRect(displayAspect: aspect, in: bounds)
+        } else {
+            displayLayer.videoGravity = .resizeAspect
+            displayLayer.frame = bounds
+        }
     }
 
     func setup(errorBinding: Binding<String?>?, isRecordingInProgress: Bool = false, recordingStartTime: Date? = nil, preferKeyframeSeek: Bool = false) {
@@ -108,6 +131,11 @@ class MPVPlayerPixelBufferView: UIView {
     }
 
     private func wireCallbacks() {
+        // Fired on mpv's VO thread when the video format changes; the new
+        // aspect ratio only becomes readable at that point.
+        session.bridge?.onReconfig = { [weak self] _, _, _ in
+            self?.updateDisplayLayerGeometryOnMain()
+        }
         session.player?.onPositionUpdate = { [weak self] position, duration in
             self?.onPositionUpdate?(position, duration)
         }
@@ -118,6 +146,9 @@ class MPVPlayerPixelBufferView: UIView {
             self?.onPlaybackRestarted?()
         }
         session.player?.onVideoInfoUpdate = { [weak self] codec, width, hwdec, audioChannels, dropped, gamma, fps in
+            // Safety net in case the aspect wasn't readable yet at reconfig
+            // time; this callback can arrive off the main thread.
+            self?.updateDisplayLayerGeometryOnMain()
             self?.onVideoInfoUpdate?(codec, width, hwdec, audioChannels, dropped, gamma, fps)
         }
     }

--- a/NexusPVR/Features/Player/VideoAspectCorrection.swift
+++ b/NexusPVR/Features/Player/VideoAspectCorrection.swift
@@ -1,0 +1,44 @@
+//
+//  VideoAspectCorrection.swift
+//  nextpvr-apple-client
+//
+//  Display geometry for the PixelBuffer renderer (issue #152).
+//
+
+import CoreGraphics
+
+/// Geometry helper for the PixelBuffer renderer.
+///
+/// `vo=pixelbuffer` hands `AVSampleBufferDisplayLayer` a `CVPixelBuffer` sized
+/// to the *coded* resolution with no sample-aspect metadata attached, so the
+/// layer treats every frame as square-pixel. Anamorphic broadcast SD — e.g. a
+/// 720x576 DVB-T feed with a 64:45 sample aspect and a 16:9 display aspect —
+/// therefore renders horizontally squeezed. The Metal/OpenGL renderers are
+/// unaffected because mpv applies the aspect itself.
+///
+/// The fix is to size the display layer to the stream's display aspect ratio
+/// and let it fill that rect, instead of letting it fit the raw pixel grid.
+enum VideoAspectCorrection {
+    /// The largest rect with the given display aspect (width / height),
+    /// centered inside `bounds`. Falls back to `bounds` when the aspect or the
+    /// bounds are unusable.
+    nonisolated static func fittedRect(displayAspect: Double, in bounds: CGRect) -> CGRect {
+        guard displayAspect.isFinite, displayAspect > 0,
+              bounds.width > 0, bounds.height > 0 else { return bounds }
+
+        let boundsAspect = Double(bounds.width / bounds.height)
+        var size = bounds.size
+        if displayAspect > boundsAspect {
+            size.height = bounds.width / CGFloat(displayAspect)
+        } else if displayAspect < boundsAspect {
+            size.width = bounds.height * CGFloat(displayAspect)
+        }
+
+        return CGRect(
+            x: bounds.minX + (bounds.width - size.width) / 2,
+            y: bounds.minY + (bounds.height - size.height) / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}

--- a/NexusPVRTests/VideoAspectCorrectionTests.swift
+++ b/NexusPVRTests/VideoAspectCorrectionTests.swift
@@ -1,0 +1,52 @@
+//
+//  VideoAspectCorrectionTests.swift
+//  NexusPVRTests
+//
+//  Tests for the PixelBuffer renderer's anamorphic aspect handling (issue #152).
+//
+
+import Testing
+import CoreGraphics
+@testable import NextPVR
+
+struct VideoAspectCorrectionTests {
+
+    @Test("Anamorphic SD (720x576, 64:45 SAR) gets a 16:9 rect, not the coded 5:4")
+    func anamorphicSDFillsWidescreenRect() {
+        let bounds = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let rect = VideoAspectCorrection.fittedRect(displayAspect: 16.0 / 9.0, in: bounds)
+        #expect(rect == bounds)
+    }
+
+    @Test("A rect wider than the view is letterboxed and centered")
+    func letterboxesWideVideo() {
+        let bounds = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+        let rect = VideoAspectCorrection.fittedRect(displayAspect: 2.0, in: bounds)
+        #expect(rect == CGRect(x: 0, y: 250, width: 1000, height: 500))
+    }
+
+    @Test("A rect taller than the view is pillarboxed and centered")
+    func pillarboxesNarrowVideo() {
+        let bounds = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+        let rect = VideoAspectCorrection.fittedRect(displayAspect: 0.5, in: bounds)
+        #expect(rect == CGRect(x: 250, y: 0, width: 500, height: 1000))
+    }
+
+    @Test("Centering respects a non-zero origin")
+    func centersWithinOffsetBounds() {
+        let bounds = CGRect(x: 100, y: 50, width: 400, height: 400)
+        let rect = VideoAspectCorrection.fittedRect(displayAspect: 2.0, in: bounds)
+        #expect(rect == CGRect(x: 100, y: 150, width: 400, height: 200))
+    }
+
+    @Test("Unusable aspects or bounds fall back to the full bounds")
+    func fallsBackWhenAspectUnknown() {
+        let bounds = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        #expect(VideoAspectCorrection.fittedRect(displayAspect: 0, in: bounds) == bounds)
+        #expect(VideoAspectCorrection.fittedRect(displayAspect: -1.5, in: bounds) == bounds)
+        #expect(VideoAspectCorrection.fittedRect(displayAspect: .nan, in: bounds) == bounds)
+        #expect(VideoAspectCorrection.fittedRect(displayAspect: .infinity, in: bounds) == bounds)
+        let empty = CGRect.zero
+        #expect(VideoAspectCorrection.fittedRect(displayAspect: 1.777, in: empty) == empty)
+    }
+}


### PR DESCRIPTION
`vo=pixelbuffer` hands AVSampleBufferDisplayLayer a CVPixelBuffer sized to the coded resolution with no sample-aspect metadata, so the layer treats every frame as square-pixel. Anamorphic broadcast SD — e.g. a 720x576 DVB-T feed with a 64:45 sample aspect and a 16:9 display aspect — rendered horizontally squeezed. The Metal/OpenGL renderers are unaffected because mpv applies the aspect itself.

Size the display layer to mpv's `video-params/aspect` and let the frames fill that rect (videoGravity .resize) instead of fitting the raw pixel grid. The geometry is refreshed on the bridge's reconfig callback — the first point the new aspect is readable — with the video-info poll as a safety net, and falls back to plain aspect-fit while the aspect is still unknown. Applies to the iOS/tvOS view and the macOS PixelBuffer controller alike.

