### PR TITLE
Add NextPVR channel groups as Guide and Channels sub-menus (#158)

### DIFF
--- a/NexusPVR/Core/Models/Channel.swift
+++ b/NexusPVR/Core/Models/Channel.swift
@@ -14,6 +14,11 @@ nonisolated struct Channel: Identifiable, Decodable, Hashable, Sendable {
     let hasIcon: Bool
     let streamURL: String?
     let groupId: Int?
+    /// Every group this channel belongs to (#158). NextPVR channel groups are
+    /// many-to-many — a channel can sit in News *and* Local — which the single
+    /// `groupId` inherited from Dispatcharr cannot express. Empty on
+    /// Dispatcharr, where `groupId` remains the source of truth.
+    let groupIds: [Int]
     let logoURL: String?
     /// Dispatcharr catch-up (timeshift) capability (#119). Always `false`/`0`
     /// on NextPVR, which has no equivalent server-side archive.
@@ -28,13 +33,14 @@ nonisolated struct Channel: Identifiable, Decodable, Hashable, Sendable {
         case streamURL = "channelDetails"
     }
 
-    init(id: Int, name: String, number: Int, hasIcon: Bool = false, streamURL: String? = nil, groupId: Int? = nil, logoURL: String? = nil, isCatchup: Bool = false, catchupDays: Int = 0) {
+    init(id: Int, name: String, number: Int, hasIcon: Bool = false, streamURL: String? = nil, groupId: Int? = nil, groupIds: [Int] = [], logoURL: String? = nil, isCatchup: Bool = false, catchupDays: Int = 0) {
         self.id = id
         self.name = name
         self.number = number
         self.hasIcon = hasIcon
         self.streamURL = streamURL
         self.groupId = groupId
+        self.groupIds = groupIds
         self.logoURL = logoURL
         self.isCatchup = isCatchup
         self.catchupDays = catchupDays
@@ -48,9 +54,16 @@ nonisolated struct Channel: Identifiable, Decodable, Hashable, Sendable {
         hasIcon = try container.decodeIfPresent(Bool.self, forKey: .hasIcon) ?? false
         streamURL = try container.decodeIfPresent(String.self, forKey: .streamURL)?.trimmingCharacters(in: .whitespaces)
         groupId = nil
+        groupIds = []
         logoURL = nil
         isCatchup = false
         catchupDays = 0
+    }
+
+    /// True when the channel is in the group with `groupId`, whichever backend
+    /// supplied the membership (#158).
+    func isMember(ofGroup groupId: Int) -> Bool {
+        self.groupId == groupId || groupIds.contains(groupId)
     }
 
     func iconURL(baseURL: String) -> URL? {
@@ -69,6 +82,25 @@ nonisolated struct Channel: Identifiable, Decodable, Hashable, Sendable {
             hasIcon: hasIcon,
             streamURL: streamURL,
             groupId: groupId,
+            groupIds: groupIds,
+            logoURL: logoURL,
+            isCatchup: isCatchup,
+            catchupDays: catchupDays
+        )
+    }
+
+    /// Returns a copy carrying the given group memberships (#158) — used to
+    /// backfill NextPVR's name-based groups onto channels decoded from
+    /// `channel.list`, whose payload has no group field.
+    func withGroupIds(_ groupIds: [Int]) -> Channel {
+        Channel(
+            id: id,
+            name: name,
+            number: number,
+            hasIcon: hasIcon,
+            streamURL: streamURL,
+            groupId: groupId,
+            groupIds: groupIds,
             logoURL: logoURL,
             isCatchup: isCatchup,
             catchupDays: catchupDays

--- a/NexusPVR/Core/Models/ChannelGroup.swift
+++ b/NexusPVR/Core/Models/ChannelGroup.swift
@@ -7,7 +7,39 @@
 
 import Foundation
 
-nonisolated struct ChannelGroup: Identifiable, Decodable, Sendable {
+nonisolated struct ChannelGroup: Identifiable, Decodable, Hashable, Sendable {
     let id: Int
     let name: String
+
+    init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    /// Builds a group from a name-only backend (#158).
+    ///
+    /// NextPVR identifies channel groups by name: `channel.groups` lists names
+    /// and `channel.list&group_id=<name>` filters by one. The shared sidebar,
+    /// filter and preference plumbing is keyed on `Int`, so derive the id from
+    /// the name instead of inventing a per-session number.
+    init(name: String) {
+        self.init(id: Self.stableId(forName: name), name: name)
+    }
+
+    /// Deterministic 32-bit FNV-1a hash of a group name.
+    ///
+    /// Unlike `String.hashValue`, which Swift seeds per process, this is stable
+    /// across launches and devices — required because the ids end up in
+    /// `UserPreferences.guideGroupIds`, which is persisted and synced via
+    /// iCloud.
+    static func stableId(forName name: String) -> Int {
+        var hash: UInt32 = 2_166_136_261
+        for byte in name.utf8 {
+            hash ^= UInt32(byte)
+            hash = hash &* 16_777_619
+        }
+        // Keep it non-negative and inside Int32 so it round-trips unchanged
+        // through JSON and property-list encodings.
+        return Int(hash & 0x7FFF_FFFF)
+    }
 }

--- a/NexusPVR/Core/Models/ChannelGroupCatalog.swift
+++ b/NexusPVR/Core/Models/ChannelGroupCatalog.swift
@@ -1,0 +1,51 @@
+//
+//  ChannelGroupCatalog.swift
+//  nextpvr-apple-client
+//
+//  Backend-neutral channel group listing plus channel membership (#158).
+//
+
+import Foundation
+
+/// The groups a server exposes together with the channels in each of them.
+///
+/// NextPVR reports groups and their members through separate requests, so this
+/// bundles both into one value the cache can apply atomically. An empty
+/// catalogue is the documented "this server has no groups" answer — never an
+/// error — so callers keep working with the full channel list.
+nonisolated struct ChannelGroupCatalog: Sendable, Equatable {
+    let groups: [ChannelGroup]
+    /// Channel id → ids of every group that channel belongs to.
+    let membership: [Int: [Int]]
+
+    init(groups: [ChannelGroup], membership: [Int: [Int]]) {
+        self.groups = groups
+        self.membership = membership
+    }
+
+    /// Builds a catalogue from each group's channel ids, inverting it into the
+    /// per-channel membership the cache needs. Duplicate ids inside a group and
+    /// duplicate group entries for a channel are both collapsed.
+    init(groups: [ChannelGroup], channelIdsByGroupId: [Int: [Int]]) {
+        var membership: [Int: [Int]] = [:]
+        for group in groups {
+            for channelId in channelIdsByGroupId[group.id] ?? [] {
+                var ids = membership[channelId] ?? []
+                if !ids.contains(group.id) {
+                    ids.append(group.id)
+                    membership[channelId] = ids
+                }
+            }
+        }
+        self.init(groups: groups, membership: membership)
+    }
+
+    static let empty = ChannelGroupCatalog(groups: [], membership: [:])
+
+    var isEmpty: Bool { groups.isEmpty }
+
+    /// Ids of the channels in `groupId`, in no particular order.
+    func channelIds(inGroup groupId: Int) -> Set<Int> {
+        Set(membership.compactMap { $0.value.contains(groupId) ? $0.key : nil })
+    }
+}

--- a/NexusPVR/Core/Models/ChannelGroupListResponse.swift
+++ b/NexusPVR/Core/Models/ChannelGroupListResponse.swift
@@ -1,0 +1,78 @@
+//
+//  ChannelGroupListResponse.swift
+//  nextpvr-apple-client
+//
+//  NextPVR `channel.groups` API response (#158).
+//
+
+import Foundation
+
+/// Decodes the NextPVR `channel.groups` payload into plain group names.
+///
+/// NextPVR's JSON serializer is hand-written per method and its group listing
+/// is name-based rather than the integer-id objects Dispatcharr returns, so
+/// this accepts either shape a server may emit:
+///
+/// ```json
+/// { "groups": ["Sports", "News"] }
+/// { "groups": [{ "name": "Sports" }, { "name": "News" }] }
+/// ```
+///
+/// A missing `groups` key decodes to no names rather than throwing — servers
+/// that don't implement the method must not break the channel load.
+nonisolated struct ChannelGroupListResponse: Decodable {
+    /// Trimmed, de-duplicated group names in server order.
+    let groupNames: [String]
+
+    init(groupNames: [String]) {
+        self.groupNames = groupNames
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case groups
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let entries = try container.decodeIfPresent([GroupEntry].self, forKey: .groups) ?? []
+        var seen = Set<String>()
+        groupNames = entries.compactMap { entry in
+            let name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, seen.insert(name).inserted else { return nil }
+            return name
+        }
+    }
+
+    /// One entry of the `groups` array — a bare string, or an object carrying
+    /// the name under one of the keys NextPVR builds have used.
+    private struct GroupEntry: Decodable {
+        let name: String
+
+        private enum NameKeys: String, CodingKey {
+            case name
+            case group
+            case groupName
+        }
+
+        init(from decoder: Decoder) throws {
+            if let single = try? decoder.singleValueContainer(),
+               let value = try? single.decode(String.self) {
+                name = value
+                return
+            }
+            let container = try decoder.container(keyedBy: NameKeys.self)
+            for key in [NameKeys.name, .groupName, .group] {
+                if let value = try? container.decodeIfPresent(String.self, forKey: key), !value.isEmpty {
+                    name = value
+                    return
+                }
+            }
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "Channel group entry has no name"
+                )
+            )
+        }
+    }
+}

--- a/NexusPVR/Core/Services/DemoDataProvider.swift
+++ b/NexusPVR/Core/Services/DemoDataProvider.swift
@@ -113,6 +113,16 @@ struct DemoDataProvider {
         ChannelGroup(id: 5, name: "Family"),
     ]
 
+    /// Groups plus membership, for backends that report the two separately
+    /// (NextPVR, #158). Derived from the demo channels' `groupId`.
+    static let channelGroupCatalog = ChannelGroupCatalog(
+        groups: channelGroups,
+        channelIdsByGroupId: Dictionary(
+            grouping: channels.filter { $0.groupId != nil },
+            by: { $0.groupId! }
+        ).mapValues { $0.map(\.id) }
+    )
+
     // MARK: - Channel Icons
 
     static func channelIconURL(channelId: Int) -> URL? {

--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -406,6 +406,31 @@ final class EPGCache: ObservableObject {
         return visibleChannels.filter { $0.isMember(ofGroup: groupId) }
     }
 
+    /// Non-empty channel groups whose name matches `search`, for the sidebar
+    /// search dropdown. Empty groups are excluded — selecting one would show a
+    /// blank guide — and an empty query matches nothing rather than everything.
+    ///
+    /// Matched against `guideSidebarChannels` rather than `visibleChannels` so
+    /// a Dispatcharr profile reload, which narrows the visible list
+    /// server-side, can't make groups disappear from search.
+    func channelGroups(matching search: String) -> [ChannelGroup] {
+        Self.channelGroups(channelGroups, matching: search, in: guideSidebarChannels)
+    }
+
+    /// Pure form of `channelGroups(matching:)`.
+    nonisolated static func channelGroups(
+        _ groups: [ChannelGroup],
+        matching search: String,
+        in channels: [Channel]
+    ) -> [ChannelGroup] {
+        guard !search.isEmpty else { return [] }
+        let query = search.lowercased()
+        return groups.filter { group in
+            group.name.lowercased().contains(query) &&
+            channels.contains { $0.isMember(ofGroup: group.id) }
+        }
+    }
+
     func filteredChannels(matching search: String) -> [Channel] {
         guard !search.isEmpty else { return visibleChannels }
         let query = search.lowercased()

--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -406,6 +406,36 @@ final class EPGCache: ObservableObject {
         return visibleChannels.filter { $0.isMember(ofGroup: groupId) }
     }
 
+    /// Channel groups that hold at least one channel. Every group-picking
+    /// surface (sidebar sub-rows, guide/channels filter panels and tvOS
+    /// drawers, the settings picker) hides empty groups, since selecting one
+    /// would leave the screen blank.
+    ///
+    /// Read from `guideSidebarChannels` rather than `visibleChannels` so a
+    /// Dispatcharr profile reload, which narrows the visible list server-side,
+    /// can't make groups disappear from the pickers.
+    var populatedChannelGroups: [ChannelGroup] {
+        Self.channelGroups(channelGroups, populatedIn: guideSidebarChannels)
+    }
+
+    /// True when at least one group holds a channel — the cheap check the
+    /// filter affordances use to decide whether to show themselves.
+    var hasPopulatedChannelGroups: Bool {
+        channelGroups.contains { group in
+            guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
+        }
+    }
+
+    /// Pure form of `populatedChannelGroups`.
+    nonisolated static func channelGroups(
+        _ groups: [ChannelGroup],
+        populatedIn channels: [Channel]
+    ) -> [ChannelGroup] {
+        groups.filter { group in
+            channels.contains { $0.isMember(ofGroup: group.id) }
+        }
+    }
+
     /// Non-empty channel groups whose name matches `search`, for the sidebar
     /// search dropdown. Empty groups are excluded — selecting one would show a
     /// blank guide — and an empty query matches nothing rather than everything.
@@ -425,10 +455,8 @@ final class EPGCache: ObservableObject {
     ) -> [ChannelGroup] {
         guard !search.isEmpty else { return [] }
         let query = search.lowercased()
-        return groups.filter { group in
-            group.name.lowercased().contains(query) &&
-            channels.contains { $0.isMember(ofGroup: group.id) }
-        }
+        return channelGroups(groups, populatedIn: channels)
+            .filter { $0.name.lowercased().contains(query) }
     }
 
     func filteredChannels(matching search: String) -> [Channel] {

--- a/NexusPVR/Core/Services/EPGCache.swift
+++ b/NexusPVR/Core/Services/EPGCache.swift
@@ -112,6 +112,8 @@ final class EPGCache: ObservableObject {
 
             #if DISPATCHERPVR
             enrichWithCatchupInfo(using: client)
+            #else
+            enrichWithChannelGroups(using: client)
             #endif
 
             // Two-phase EPG load:
@@ -262,6 +264,8 @@ final class EPGCache: ObservableObject {
 
             #if DISPATCHERPVR
             enrichWithCatchupInfo(using: client)
+            #else
+            enrichWithChannelGroups(using: client)
             #endif
 
             startBackgroundFullLoad(using: client, channels: sorted, totalStart: totalStart)
@@ -341,6 +345,36 @@ final class EPGCache: ObservableObject {
         guideSidebarChannels = apply(guideSidebarChannels)
         channelMap = Dictionary(channels.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     }
+    #else
+    /// Loads NextPVR's channel groups and stamps membership onto the cached
+    /// channels (#158).
+    ///
+    /// Discovery costs one request for the group list plus one per group, so it
+    /// runs in the background after the grid has painted rather than delaying
+    /// first paint; the sidebar, settings picker and filters pick the groups up
+    /// reactively. Runs on every load *and* refresh so server-side group edits
+    /// appear without restarting the app.
+    private func enrichWithChannelGroups(using client: PVRClient) {
+        Task { [weak self] in
+            guard let self else { return }
+            let catalog = (try? await client.getChannelGroupCatalog()) ?? .empty
+            self.applyChannelGroups(catalog)
+        }
+    }
+
+    /// Replaces the cached group metadata. An empty catalogue clears it, which
+    /// is what a server with no (or no longer any) custom groups should show —
+    /// the all-channel lists themselves are untouched.
+    func applyChannelGroups(_ catalog: ChannelGroupCatalog) {
+        channelGroups = catalog.groups
+        func apply(_ list: [Channel]) -> [Channel] {
+            list.map { $0.withGroupIds(catalog.membership[$0.id] ?? []) }
+        }
+        channels = apply(channels)
+        visibleChannels = apply(visibleChannels)
+        guideSidebarChannels = apply(guideSidebarChannels)
+        channelMap = Dictionary(channels.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+    }
     #endif
 
     /// Prefetch yesterday + tomorrow EPG in background
@@ -369,7 +403,7 @@ final class EPGCache: ObservableObject {
 
     func channels(inGroup groupId: Int?) -> [Channel] {
         guard let groupId else { return visibleChannels }
-        return visibleChannels.filter { $0.groupId == groupId }
+        return visibleChannels.filter { $0.isMember(ofGroup: groupId) }
     }
 
     func filteredChannels(matching search: String) -> [Channel] {

--- a/NexusPVR/Core/Services/NextPVRClient.swift
+++ b/NexusPVR/Core/Services/NextPVRClient.swift
@@ -510,6 +510,79 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         return response.channels ?? []
     }
 
+    /// The server's custom channel groups and the channels in each (#158).
+    ///
+    /// NextPVR keys groups by name: `channel.groups` lists them and
+    /// `channel.list&group_id=<name>` returns only that group's channels, so
+    /// membership costs one request per group. Those run concurrently, and a
+    /// group whose request fails is reported as empty rather than failing the
+    /// whole catalogue.
+    ///
+    /// Never throws for an unsupported or group-less server — it returns
+    /// `ChannelGroupCatalog.empty`, so the plain `channel.list` catalogue keeps
+    /// working as the complete channel list.
+    func getChannelGroupCatalog() async throws -> ChannelGroupCatalog {
+        guard !config.isDemoMode else { return DemoDataProvider.channelGroupCatalog }
+
+        let names: [String]
+        do {
+            let response: ChannelGroupListResponse = try await request("channel.groups")
+            names = response.groupNames
+        } catch {
+            // Older builds — and servers with the method disabled — answer with
+            // an error or an unparseable body. Groups are optional, so degrade
+            // to "no groups" instead of breaking the channel load.
+            print("[NextPVR] channel.groups unavailable: \(error.localizedDescription)")
+            return .empty
+        }
+
+        let groups = names.map { ChannelGroup(name: $0) }
+        guard !groups.isEmpty else { return .empty }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        let channelIdsByGroupId = await channelIdsPerGroup(groups)
+        print("[NextPVR] Channel groups: \(groups.count) in \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - start) * 1000))ms")
+        return ChannelGroupCatalog(groups: groups, channelIdsByGroupId: channelIdsByGroupId)
+    }
+
+    /// Resolves each group's channel ids, capping how many `channel.list`
+    /// requests are in flight at once the same way the EPG fetch does.
+    private func channelIdsPerGroup(_ groups: [ChannelGroup]) async -> [Int: [Int]] {
+        let concurrency = 5
+        var result: [Int: [Int]] = [:]
+        result.reserveCapacity(groups.count)
+
+        var index = 0
+        await withTaskGroup(of: (Int, [Int]).self) { taskGroup in
+            func addTask(for group: ChannelGroup) {
+                taskGroup.addTask { [self] in
+                    let channels = (try? await self.channels(inGroupNamed: group.name)) ?? []
+                    return (group.id, channels.map(\.id))
+                }
+            }
+
+            while index < groups.count && index < concurrency {
+                addTask(for: groups[index])
+                index += 1
+            }
+            for await (groupId, channelIds) in taskGroup {
+                result[groupId] = channelIds
+                if index < groups.count {
+                    addTask(for: groups[index])
+                    index += 1
+                }
+            }
+        }
+        return result
+    }
+
+    /// `channel.list` narrowed to one group. The group name is the id NextPVR
+    /// expects; `URLComponents` percent-encodes it.
+    private func channels(inGroupNamed name: String) async throws -> [Channel] {
+        let response: ChannelListResponse = try await request("channel.list", params: ["group_id": name])
+        return response.channels ?? []
+    }
+
     // MARK: - EPG / Listings
 
     func getListings(channelId: Int) async throws -> [Program] {

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -37,15 +37,14 @@ struct ChannelsView: View {
     /// the pressed card in here, the press did not move focus — the card has
     /// no neighbor to its left, i.e. it sits in the leftmost column.
     @State private var lastKnownFocusedChannelId: Int?
-    #if DISPATCHERPVR
     @State private var headerDrawerKind: ChannelsDrawerKind?
     @FocusState private var focusedDrawerItemId: String?
     #endif
-    #endif
 
-    #if os(tvOS) && DISPATCHERPVR
+    #if os(tvOS)
     /// Which header filter is currently expanded as a drawer, matching the
-    /// guide view's group/profile drawer UX.
+    /// guide view's group/profile drawer UX. `.profile` is only ever opened in
+    /// the Dispatcharr build, which is the only backend with channel profiles.
     private enum ChannelsDrawerKind { case group, profile }
     #endif
 
@@ -92,7 +91,6 @@ struct ChannelsView: View {
         }
     }
 
-    #if DISPATCHERPVR
     private var hasFilterData: Bool {
         !epgCache.channelProfiles.isEmpty || !populatedGroups.isEmpty
     }
@@ -117,6 +115,7 @@ struct ChannelsView: View {
         return "All Groups"
     }
 
+    #if DISPATCHERPVR
     private var selectedProfileLabel: String {
         if let profileId = appState.guideProfileFilter,
            let profile = epgCache.channelProfiles.first(where: { $0.id == profileId }) {
@@ -142,7 +141,6 @@ struct ChannelsView: View {
             }
             .background(.ultraThinMaterial)
             .onMoveCommand { direction in
-                #if DISPATCHERPVR
                 if headerDrawerKind != nil {
                     // Up/down navigates the drawer list (handled by the focus
                     // engine); left/right collapses it, like the guide view.
@@ -151,7 +149,6 @@ struct ChannelsView: View {
                     }
                     return
                 }
-                #endif
                 // Matches the guide: left only hands focus to the sidebar from
                 // the leftmost column — everywhere else the focus engine moves
                 // to the adjacent card (#111). Focus has already been updated
@@ -171,12 +168,10 @@ struct ChannelsView: View {
                 lastKnownFocusedChannelId = nil
             }
             .onExitCommand {
-                #if DISPATCHERPVR
                 if headerDrawerKind != nil {
                     closeDrawer()
                     return
                 }
-                #endif
                 requestSidebarFocus()
             }
             .task {
@@ -210,7 +205,6 @@ struct ChannelsView: View {
             content
             .navigationTitle("Channels")
             .accessibilityIdentifier("channels-view")
-            #if DISPATCHERPVR
             .toolbar {
                 if hasFilterData {
                     ToolbarItem(placement: .automatic) {
@@ -218,7 +212,6 @@ struct ChannelsView: View {
                     }
                 }
             }
-            #endif
             .searchable(text: $appState.guideChannelFilter, prompt: "Search channels")
             .sidebarMenuToolbar()
             .alert("Error", isPresented: .constant(streamError != nil)) {
@@ -362,11 +355,7 @@ struct ChannelsView: View {
     /// outer focusable `Button` that swallows the inner button's focus — making
     /// the filter impossible to reset on tvOS.
     private var emptyStateHasFocusableButton: Bool {
-        #if DISPATCHERPVR
-        return hasActiveFilters
-        #else
-        return false
-        #endif
+        hasActiveFilters
     }
 
     @ViewBuilder
@@ -393,7 +382,6 @@ struct ChannelsView: View {
                     .foregroundStyle(Theme.textSecondary)
                     .multilineTextAlignment(.center)
             }
-            #if DISPATCHERPVR
             if hasActiveFilters {
                 Button("Clear Filters") {
                     appState.guideChannelFilter = ""
@@ -403,7 +391,6 @@ struct ChannelsView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(Theme.accent)
             }
-            #endif
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -416,11 +403,7 @@ struct ChannelsView: View {
     }
 
     private var emptyTitle: String {
-        #if DISPATCHERPVR
-        return hasActiveFilters ? "No channels match filters" : "No channels available"
-        #else
-        return appState.guideChannelFilter.isEmpty ? "No channels available" : "No matches"
-        #endif
+        hasActiveFilters ? "No channels match filters" : "No channels available"
     }
 
     private var emptyContent: some View {
@@ -434,12 +417,10 @@ struct ChannelsView: View {
         emptyView
         #else
         VStack(spacing: 0) {
-            #if DISPATCHERPVR
             if showFilters && hasFilterData {
                 filterPanel
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
-            #endif
             emptyView
         }
         #endif
@@ -461,12 +442,10 @@ struct ChannelsView: View {
         }
         #else
         VStack(spacing: 0) {
-            #if DISPATCHERPVR
             if showFilters && hasFilterData {
                 filterPanel
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
-            #endif
             ScrollView {
                 cardsGrid
             }
@@ -547,25 +526,25 @@ struct ChannelsView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: Theme.spacingLG) {
                 tvOSSearchField
-                #if DISPATCHERPVR
                 if hasFilterData {
                     Rectangle()
                         .fill(Theme.surfaceHighlight)
                         .frame(width: 1, height: 30)
-                    tvOSDispatcharrField(
+                    tvOSFilterField(
                         icon: "folder.fill",
                         title: "Group",
                         value: selectedGroupLabel,
                         kind: .group
                     )
-                    tvOSDispatcharrField(
+                    #if DISPATCHERPVR
+                    tvOSFilterField(
                         icon: "person.fill",
                         title: "Profile",
                         value: selectedProfileLabel,
                         kind: .profile
                     )
+                    #endif
                 }
-                #endif
 
                 tvOSRefreshButton
 
@@ -583,12 +562,10 @@ struct ChannelsView: View {
                     .stroke(Theme.surfaceHighlight.opacity(0.5), lineWidth: 1)
             )
 
-            #if DISPATCHERPVR
             if headerDrawerKind != nil {
                 tvOSHeaderDrawer
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
-            #endif
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 4)
@@ -649,8 +626,7 @@ struct ChannelsView: View {
         )
     }
 
-    #if DISPATCHERPVR
-    private func tvOSDispatcharrField(icon: String, title: String, value: String, kind: ChannelsDrawerKind) -> some View {
+    private func tvOSFilterField(icon: String, title: String, value: String, kind: ChannelsDrawerKind) -> some View {
         Button {
             if headerDrawerKind == kind {
                 closeDrawer()
@@ -719,8 +695,12 @@ struct ChannelsView: View {
             return [(id: "group-all", label: "All Groups", value: nil)] +
                    populatedGroups.map { (id: "group-\($0.id)", label: $0.name, value: $0.id) }
         case .profile:
+            #if DISPATCHERPVR
             return [(id: "profile-all", label: "All Profiles", value: nil)] +
                    epgCache.channelProfiles.map { (id: "profile-\($0.id)", label: $0.name, value: $0.id) }
+            #else
+            return []
+            #endif
         case .none:
             return []
         }
@@ -770,9 +750,7 @@ struct ChannelsView: View {
         closeDrawer()
     }
     #endif
-    #endif
 
-    #if DISPATCHERPVR
     private var filterToggleButton: some View {
         Button {
             withAnimation(.easeInOut(duration: Theme.animationDuration)) {
@@ -792,6 +770,7 @@ struct ChannelsView: View {
 
     private var filterPanel: some View {
         VStack(alignment: .leading, spacing: 4) {
+            #if DISPATCHERPVR
             if !epgCache.channelProfiles.isEmpty {
                 filterRow(
                     label: "Profile",
@@ -805,6 +784,7 @@ struct ChannelsView: View {
                     }
                 }
             }
+            #endif
 
             if !populatedGroups.isEmpty {
                 filterRow(
@@ -865,7 +845,6 @@ struct ChannelsView: View {
         }
         .buttonStyle(.plain)
     }
-    #endif
 
     #if os(macOS)
     /// macOS nav bar, mirroring the guide's `macOSGuideNavBar`: a capsule search
@@ -918,7 +897,6 @@ struct ChannelsView: View {
                 .accessibilityLabel("Refresh channels")
                 .accessibilityIdentifier("channels-refresh-button")
 
-                #if DISPATCHERPVR
                 if hasFilterData {
                     Button {
                         withAnimation(.easeInOut(duration: Theme.animationDuration)) {
@@ -938,17 +916,14 @@ struct ChannelsView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel(showFilters ? "Hide filters" : "Show filters")
                 }
-                #endif
             }
             .padding(.horizontal, Theme.spacingMD)
             .padding(.vertical, Theme.spacingSM)
 
-            #if DISPATCHERPVR
             if showFilters && hasFilterData {
                 filterPanel
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
-            #endif
         }
     }
     #endif
@@ -1114,8 +1089,8 @@ private struct ChannelGridCardFocusWrapper<Content: View>: View {
 }
 
 /// tvOS `ButtonStyle` for the pill-shaped fields in the filter bar (search and
-/// the Dispatcharr group/profile chips). Mirrors the guide's `tvOSSearchField`
-/// / `tvOSDispatcharrField` look: white fill + dark text + scale when focused.
+/// the group/profile chips). Mirrors the guide's `tvOSSearchField` /
+/// `tvOSDispatcharrField` look: white fill + dark text + scale when focused.
 struct TVPillFieldButtonStyle: ButtonStyle {
     var unfocusedForeground: Color
 
@@ -1154,7 +1129,6 @@ private struct TVPillFieldFocusWrapper<Content: View>: View {
     }
 }
 
-#if DISPATCHERPVR
 /// tvOS `ButtonStyle` for rows in the group/profile drawer. Highlighted
 /// (focused) row shows a filled checkmark + accent border, matching the guide
 /// view's `tvOSHeaderDrawer` rows.
@@ -1195,7 +1169,6 @@ private struct ChannelsDrawerItemFocusWrapper<Content: View>: View {
         .animation(.easeInOut(duration: 0.12), value: isFocused)
     }
 }
-#endif
 
 /// Zero-size `UITextField` that only ever drives the on-screen keyboard for the
 /// search field. `canBecomeFocused` is `false` so the focus engine never lands

--- a/NexusPVR/Features/Channels/ChannelsView.swift
+++ b/NexusPVR/Features/Channels/ChannelsView.swift
@@ -76,7 +76,12 @@ struct ChannelsView: View {
             let channelIds = Set(profile.channels)
             result = result.filter { channelIds.contains($0.id) }
         } else if let groupId = appState.guideGroupFilter {
-            result = result.filter { $0.groupId == groupId }
+            result = result.filter { $0.isMember(ofGroup: groupId) }
+        }
+        #else
+        // NextPVR has no channel profiles, but does have groups (#158).
+        if let groupId = appState.guideGroupFilter {
+            result = result.filter { $0.isMember(ofGroup: groupId) }
         }
         #endif
         guard !appState.guideChannelFilter.isEmpty else { return result }
@@ -100,7 +105,7 @@ struct ChannelsView: View {
 
     private var populatedGroups: [ChannelGroup] {
         epgCache.channelGroups.filter { group in
-            epgCache.channels.contains { $0.groupId == group.id }
+            epgCache.channels.contains { $0.isMember(ofGroup: group.id) }
         }
     }
 

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -54,17 +54,19 @@ struct GuideView: View {
     private let channelWidth: CGFloat = Theme.channelColumnWidth
     private let rowHeight: CGFloat = Theme.cellHeight
 
-    #if DISPATCHERPVR
     private var hasFilterData: Bool {
         !epgCache.channelProfiles.isEmpty || hasPopulatedGroups
     }
 
     private var hasPopulatedGroups: Bool {
-        epgCache.channelGroups.contains { group in
-            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-        }
+        epgCache.hasPopulatedChannelGroups
     }
-    #endif
+
+    /// Groups the filter surfaces offer — empty groups are hidden, since
+    /// picking one would leave the guide blank.
+    private var populatedGroups: [ChannelGroup] {
+        epgCache.populatedChannelGroups
+    }
 
     var body: some View {
         // The modifier chain is split across small generic helpers so the Swift
@@ -249,7 +251,7 @@ struct GuideView: View {
                 .offset(y: -50)
         }
         #endif
-        #if os(iOS) && DISPATCHERPVR
+        #if os(iOS)
         .overlay(alignment: .top) {
             if viewModel.showFilters && hasFilterData {
                 filterPanel
@@ -437,7 +439,6 @@ struct GuideView: View {
                 .accessibilityIdentifier("guide-refresh-button")
                 .padding(.trailing, Theme.spacingSM)
 
-                #if DISPATCHERPVR
                 if hasFilterData {
                     Button {
                         withAnimation(.easeInOut(duration: 0.25)) {
@@ -457,17 +458,14 @@ struct GuideView: View {
                     .buttonStyle(.plain)
                     .padding(.trailing, Theme.spacingSM)
                 }
-                #endif
             }
             .padding(.horizontal, Theme.spacingMD)
             .padding(.vertical, Theme.spacingSM)
 
-            #if DISPATCHERPVR
             if viewModel.showFilters && hasFilterData {
                 filterPanel
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
-            #endif
         }
     }
     #endif
@@ -481,7 +479,6 @@ struct GuideView: View {
         #else
         let base: CGFloat = 0
         #endif
-        #if DISPATCHERPVR
         var extra: CGFloat = 0
         if viewModel.showFilters && hasFilterData {
             // Add space for each filter row shown
@@ -490,25 +487,20 @@ struct GuideView: View {
             if hasPopulatedGroups { extra += 36 }
         }
         return base + extra
-        #else
-        return base
-        #endif
     }
     #endif
 
-    #if DISPATCHERPVR
     @ViewBuilder
     private var filterPanel: some View {
         VStack(alignment: .leading, spacing: 4) {
+            #if DISPATCHERPVR
             if !epgCache.channelProfiles.isEmpty {
                 filterRow(label: "Profile", items: epgCache.channelProfiles.map { (id: $0.id, name: $0.name) },
                           selectedId: viewModel.selectedProfileId) { id in
                     viewModel.selectedProfileId = id
                 }
             }
-            let populatedGroups = epgCache.channelGroups.filter { group in
-                epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-            }
+            #endif
             if !populatedGroups.isEmpty {
                 filterRow(label: "Group", items: populatedGroups.map { (id: $0.id, name: $0.name) },
                           selectedId: viewModel.selectedGroupId) { id in
@@ -556,7 +548,6 @@ struct GuideView: View {
         }
         .buttonStyle(.plain)
     }
-    #endif
 
     private var loadingView: some View {
         VStack(spacing: Theme.spacingMD) {
@@ -993,8 +984,8 @@ struct GuideView: View {
         case previousDay
         case nextDay
         case search
-        #if DISPATCHERPVR
         case group
+        #if DISPATCHERPVR
         case profile
         #endif
         case refresh
@@ -1002,14 +993,16 @@ struct GuideView: View {
 
     private var tvHeaderItems: [TVGuideHeaderItem] {
         var items: [TVGuideHeaderItem] = [.previousDay, .nextDay, .search]
+        if hasPopulatedGroups { items.append(.group) }
         #if DISPATCHERPVR
-        items.append(contentsOf: [.group, .profile])
+        items.append(.profile)
         #endif
         items.append(.refresh)
         return items
     }
 
-    #if DISPATCHERPVR
+    /// `.profile` is only ever opened in the Dispatcharr build — channel
+    /// profiles have no NextPVR equivalent.
     private enum TVGuideDrawerKind {
         case group
         case profile
@@ -1029,31 +1022,27 @@ struct GuideView: View {
     private var currentDrawerItems: [TVGuideDrawerItem] {
         switch headerDrawerKind {
         case .group:
-            let populatedGroups = epgCache.channelGroups.filter { group in
-                epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-            }
             return [TVGuideDrawerItem(id: "group-all", label: "All Groups", value: nil)] +
                    populatedGroups.map { TVGuideDrawerItem(id: "group-\($0.id)", label: $0.name, value: $0.id) }
         case .profile:
+            #if DISPATCHERPVR
             return [TVGuideDrawerItem(id: "profile-all", label: "All Profiles", value: nil)] +
                    epgCache.channelProfiles.map { TVGuideDrawerItem(id: "profile-\($0.id)", label: $0.name, value: $0.id) }
+            #else
+            return []
+            #endif
         case .none:
             return []
         }
     }
-    #endif
 
     private var tvOSGuideContent: some View {
         GeometryReader { geometry in
             let gridWidth = geometry.size.width - channelWidth
             let pxPerMinute = gridWidth / visibleMinutes
             let filterRowHeight: CGFloat = 70
-            #if DISPATCHERPVR
             let drawerContentHeight = 60 + CGFloat(currentDrawerItems.count) * 52
             let drawerHeight: CGFloat = isHeaderDrawerOpen ? min(320, max(170, drawerContentHeight)) : 0
-            #else
-            let drawerHeight: CGFloat = 0
-            #endif
 
             // Grid — manual offset driven by scrollTopRow (keep-in-view scrolling)
             let totalRows = viewModel.channels.count
@@ -1072,13 +1061,11 @@ struct GuideView: View {
                     focusedItem: focusedHeaderItem
                 )
                 .frame(height: filterRowHeight)
-                #if DISPATCHERPVR
                 if isHeaderDrawerOpen {
                     tvOSHeaderDrawer
                         .frame(height: drawerHeight)
                         .transition(.move(edge: .top).combined(with: .opacity))
                 }
-                #endif
 
                 // Channel rows
                 VStack(spacing: 0) {
@@ -1151,9 +1138,7 @@ struct GuideView: View {
                 scrollTopRow = 0
             }
             endTVSearchEditing()
-            #if DISPATCHERPVR
             closeHeaderDrawer()
-            #endif
         }
     }
 
@@ -1361,14 +1346,16 @@ struct GuideView: View {
             // Search / active filter
             tvOSSearchField(isFocused: isFocused && focusedItem == .search)
 
+            if hasPopulatedGroups {
+                tvOSFilterField(
+                    icon: "folder.fill",
+                    title: "Group",
+                    value: selectedGroupLabel,
+                    isFocused: isFocused && focusedItem == .group
+                )
+            }
             #if DISPATCHERPVR
-            tvOSDispatcharrField(
-                icon: "folder.fill",
-                title: "Group",
-                value: selectedGroupLabel,
-                isFocused: isFocused && focusedItem == .group
-            )
-            tvOSDispatcharrField(
+            tvOSFilterField(
                 icon: "person.fill",
                 title: "Profile",
                 value: selectedProfileLabel,
@@ -1409,6 +1396,7 @@ struct GuideView: View {
         return "All Groups"
     }
 
+    #if DISPATCHERPVR
     private var selectedProfileLabel: String {
         if let profileId = viewModel.selectedProfileId,
            let profile = epgCache.channelProfiles.first(where: { $0.id == profileId }) {
@@ -1416,6 +1404,7 @@ struct GuideView: View {
         }
         return "All Profiles"
     }
+    #endif
 
     private func tvOSSearchField(isFocused: Bool) -> some View {
         let isActive = isFocused || isTVSearchFieldFocused
@@ -1467,7 +1456,7 @@ struct GuideView: View {
         }
     }
 
-    private func tvOSDispatcharrField(
+    private func tvOSFilterField(
         icon: String,
         title: String,
         value: String,
@@ -1498,7 +1487,6 @@ struct GuideView: View {
         .animation(.easeInOut(duration: 0.14), value: isFocused)
     }
 
-    #if DISPATCHERPVR
     private var tvOSHeaderDrawer: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text(headerDrawerKind == .group ? "Select Group" : "Select Profile")
@@ -1546,7 +1534,6 @@ struct GuideView: View {
         .padding(.horizontal, 8)
         .padding(.bottom, 6)
     }
-    #endif
 
     private func tvOSHeaderField(
         imageName: String,
@@ -1580,7 +1567,6 @@ struct GuideView: View {
         focusedColumn = 0
     }
 
-    #if DISPATCHERPVR
     private func openHeaderDrawer(_ kind: TVGuideDrawerKind) {
         headerDrawerKind = kind
         let selectedValue: Int? = (kind == .group) ? viewModel.selectedGroupId : viewModel.selectedProfileId
@@ -1621,17 +1607,12 @@ struct GuideView: View {
             break
         }
     }
-    #endif
-
-
 
     private func handleTVNavigation(_ direction: MoveCommandDirection) {
-        #if DISPATCHERPVR
         if isHeaderDrawerOpen {
             handleHeaderDrawerNavigation(direction)
             return
         }
-        #endif
 
         if isTVSearchFieldFocused {
             endTVSearchEditing()
@@ -1731,22 +1712,28 @@ struct GuideView: View {
     }
 
     private func moveHeaderFocusLeft() {
-        guard let currentIndex = tvHeaderItems.firstIndex(of: focusedHeaderItem) else { return }
-        focusedHeaderItem = tvHeaderItems[max(0, currentIndex - 1)]
+        let items = tvHeaderItems
+        guard let currentIndex = items.firstIndex(of: focusedHeaderItem) else {
+            focusedHeaderItem = items[0]
+            return
+        }
+        focusedHeaderItem = items[max(0, currentIndex - 1)]
     }
 
     private func moveHeaderFocusRight() {
-        guard let currentIndex = tvHeaderItems.firstIndex(of: focusedHeaderItem) else { return }
-        focusedHeaderItem = tvHeaderItems[min(tvHeaderItems.count - 1, currentIndex + 1)]
+        let items = tvHeaderItems
+        guard let currentIndex = items.firstIndex(of: focusedHeaderItem) else {
+            focusedHeaderItem = items[0]
+            return
+        }
+        focusedHeaderItem = items[min(items.count - 1, currentIndex + 1)]
     }
 
     private func handleTVSelect() {
-        #if DISPATCHERPVR
         if isHeaderDrawerOpen {
             applyDrawerSelection()
             return
         }
-        #endif
         if isTVSearchFieldFocused {
             endTVSearchEditing()
             clampFocusedRowToChannels()
@@ -1771,10 +1758,11 @@ struct GuideView: View {
             Task { await viewModel.navigateToDate(using: client) }
         case .search:
             beginTVSearchEditing()
-        #if DISPATCHERPVR
         case .group:
+            guard hasPopulatedGroups else { return }
             endTVSearchEditing()
             openHeaderDrawer(.group)
+        #if DISPATCHERPVR
         case .profile:
             endTVSearchEditing()
             openHeaderDrawer(.profile)

--- a/NexusPVR/Features/Guide/GuideView.swift
+++ b/NexusPVR/Features/Guide/GuideView.swift
@@ -61,7 +61,7 @@ struct GuideView: View {
 
     private var hasPopulatedGroups: Bool {
         epgCache.channelGroups.contains { group in
-            epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
         }
     }
     #endif
@@ -153,7 +153,6 @@ struct GuideView: View {
             .onChange(of: appState.guideProfileFilter) {
                 Task { viewModel.selectedProfileId = appState.guideProfileFilter }
             }
-            #if DISPATCHERPVR
             .onChange(of: viewModel.selectedGroupId) { _, groupId in
                 if groupId != nil {
                     viewModel.selectedProfileId = nil
@@ -161,6 +160,7 @@ struct GuideView: View {
                 }
                 appState.guideGroupFilter = groupId
             }
+            #if DISPATCHERPVR
             .onChange(of: viewModel.selectedProfileId) { _, profileId in
                 Task {
                     await epgCache.reloadData(using: client, profileId: profileId)
@@ -507,7 +507,7 @@ struct GuideView: View {
                 }
             }
             let populatedGroups = epgCache.channelGroups.filter { group in
-                epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
             }
             if !populatedGroups.isEmpty {
                 filterRow(label: "Group", items: populatedGroups.map { (id: $0.id, name: $0.name) },
@@ -1030,7 +1030,7 @@ struct GuideView: View {
         switch headerDrawerKind {
         case .group:
             let populatedGroups = epgCache.channelGroups.filter { group in
-                epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
             }
             return [TVGuideDrawerItem(id: "group-all", label: "All Groups", value: nil)] +
                    populatedGroups.map { TVGuideDrawerItem(id: "group-\($0.id)", label: $0.name, value: $0.id) }

--- a/NexusPVR/Features/Guide/GuideViewModel.swift
+++ b/NexusPVR/Features/Guide/GuideViewModel.swift
@@ -173,7 +173,7 @@ final class GuideViewModel: ObservableObject {
         } else {
             result = cache.channels(inProfile: nil)
             if let groupId = selectedGroupId {
-                result = result.filter { $0.groupId == groupId }
+                result = result.filter { $0.isMember(ofGroup: groupId) }
             }
         }
         if !channelSearchText.isEmpty {

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -31,9 +31,9 @@ struct SettingsView: View {
     #if os(tvOS)
     @State private var uiFontSize: UIFontSize = UserPreferences.load().uiFontSize
     #endif
-    #if DISPATCHERPVR
     @State private var guideShowGroupsInSidebar: Bool = UserPreferences.load().guideShowGroupsInSidebar
     @State private var guideGroupIds: [Int] = UserPreferences.load().guideGroupIds
+    #if DISPATCHERPVR
     @State private var guideShowProfilesInSidebar: Bool = UserPreferences.load().guideShowProfilesInSidebar
     @State private var guideProfileIds: [Int] = UserPreferences.load().guideProfileIds
     #endif
@@ -80,9 +80,7 @@ struct SettingsView: View {
                 serverSection
                 generalSection
                 playbackSection
-                #if DISPATCHERPVR
                 guideSection
-                #endif
                 #if DEBUG
                 debugStreamSection
                 #endif
@@ -264,11 +262,9 @@ struct SettingsView: View {
                     }
                     .focusSection()
 
-                #if DISPATCHERPVR
                     tvOSGuideSettingsSection
                         .focusSection()
 
-                #endif
 
                 #if DEBUG
                     TVSettingsSection(
@@ -482,7 +478,7 @@ struct SettingsView: View {
     /// info so the Network panel is no longer needed.
     #endif
 
-    #if os(tvOS) && DISPATCHERPVR
+    #if os(tvOS)
     private var tvOSGuideSettingsSection: some View {
         TVSettingsSection(
             title: "Guide",
@@ -512,7 +508,7 @@ struct SettingsView: View {
                         tvOSGuideStatusRow("No channel groups available")
                     } else {
                         let populatedGroups = epgCache.channelGroups.filter { group in
-                            epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                         }
                         if populatedGroups.isEmpty {
                             tvOSGuideStatusRow("No channels in any group")
@@ -530,6 +526,8 @@ struct SettingsView: View {
                     }
                 }
 
+                // Channel profiles are a Dispatcharr concept; NextPVR only has groups.
+                #if DISPATCHERPVR
                 Toggle("Show Profiles in Sidebar", isOn: $guideShowProfilesInSidebar)
                     .font(.tvScaled(size: 24, weight: .semibold))
                     .modifier(TVGuideSidebarToggleForegroundStyle())
@@ -570,6 +568,7 @@ struct SettingsView: View {
                         }
                     }
                 }
+                #endif
             }
         }
     }
@@ -609,6 +608,7 @@ struct SettingsView: View {
         .buttonStyle(TVSettingsRowButtonStyle())
     }
 
+    #if DISPATCHERPVR
     private func tvOSGuideProfileToggleRow(profile: ChannelProfile) -> some View {
         let isSelected = guideProfileIds.contains(profile.id)
 
@@ -632,6 +632,7 @@ struct SettingsView: View {
         }
         .buttonStyle(TVSettingsRowButtonStyle())
     }
+    #endif
     #endif
 
     private var serverSummaryValue: String {
@@ -1289,7 +1290,6 @@ struct SettingsView: View {
         }
     }
 
-    #if DISPATCHERPVR
     private var guideSection: some View {
         Section {
             Toggle("Show Groups in Sidebar", isOn: $guideShowGroupsInSidebar)
@@ -1309,7 +1309,7 @@ struct SettingsView: View {
                         .foregroundStyle(Theme.textSecondary)
                 } else {
                     let populatedGroups = epgCache.channelGroups.filter { group in
-                        epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                        epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                     }
                     if populatedGroups.isEmpty {
                         Text("No channels in any group")
@@ -1346,6 +1346,8 @@ struct SettingsView: View {
                 }
             }
 
+            // Channel profiles are a Dispatcharr concept; NextPVR only has groups.
+            #if DISPATCHERPVR
             Toggle("Show Profiles in Sidebar", isOn: $guideShowProfilesInSidebar)
                 .onChange(of: guideShowProfilesInSidebar) { newValue in
                     var prefs = UserPreferences.load()
@@ -1399,11 +1401,11 @@ struct SettingsView: View {
                     }
                 }
             }
+            #endif
         } header: {
             Text("Guide")
         }
     }
-    #endif
 
     #if DISPATCHERPVR
     /// iOS / macOS row showing the server's public IP and geo location
@@ -1482,7 +1484,6 @@ struct SettingsView: View {
 }
 
 #if os(tvOS)
-#if DISPATCHERPVR
 private struct TVGuideSidebarToggleForegroundStyle: ViewModifier {
     @Environment(\.isFocused) private var isFocused
 
@@ -1517,7 +1518,6 @@ private struct TVGuideToggleRowContent: View {
         .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSM))
     }
 }
-#endif
 
 private struct TVSettingsRowButtonStyle: ButtonStyle {
     @Environment(\.isFocused) private var isFocused

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -507,9 +507,7 @@ struct SettingsView: View {
                     if epgCache.channelGroups.isEmpty {
                         tvOSGuideStatusRow("No channel groups available")
                     } else {
-                        let populatedGroups = epgCache.channelGroups.filter { group in
-                            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                        }
+                        let populatedGroups = epgCache.populatedChannelGroups
                         if populatedGroups.isEmpty {
                             tvOSGuideStatusRow("No channels in any group")
                         } else {
@@ -1308,9 +1306,7 @@ struct SettingsView: View {
                     Text("No channel groups available")
                         .foregroundStyle(Theme.textSecondary)
                 } else {
-                    let populatedGroups = epgCache.channelGroups.filter { group in
-                        epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                    }
+                    let populatedGroups = epgCache.populatedChannelGroups
                     if populatedGroups.isEmpty {
                         Text("No channels in any group")
                             .foregroundStyle(Theme.textSecondary)

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -423,14 +423,7 @@ struct IOSNavigation: View {
                 guard !Task.isCancelled else { return }
                 channelMatchCount = channels
                 programMatchCount = programs
-                #if DISPATCHERPVR
-                let query = newValue.lowercased()
-                let groupsWithChannels = epgCache.channelGroups.filter { group in
-                    group.name.lowercased().contains(query) &&
-                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                }
-                matchingGroups = groupsWithChannels
-                #endif
+                matchingGroups = epgCache.channelGroups(matching: newValue)
                 lastSearchedText = newValue
                 withAnimation(.easeInOut(duration: 0.2)) {
                     showSearchDropdown = true
@@ -1117,7 +1110,6 @@ struct IOSNavigation: View {
             }
             .disabled(channelMatchCount == 0)
 
-            #if DISPATCHERPVR
             if !matchingGroups.isEmpty {
                 Divider().overlay(Theme.surfaceHighlight)
 
@@ -1148,7 +1140,6 @@ struct IOSNavigation: View {
                     }
                 }
             }
-            #endif
 
             Divider().overlay(Theme.surfaceHighlight)
 
@@ -2055,14 +2046,7 @@ struct MacOSNavigation: View {
                 guard !Task.isCancelled else { return }
                 channelMatchCount = channels
                 programMatchCount = programs
-                #if DISPATCHERPVR
-                let query = newValue.lowercased()
-                let groupsWithChannels = epgCache.channelGroups.filter { group in
-                    group.name.lowercased().contains(query) &&
-                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                }
-                matchingGroups = groupsWithChannels
-                #endif
+                matchingGroups = epgCache.channelGroups(matching: newValue)
                 lastSearchedText = newValue
                 withAnimation(.easeInOut(duration: 0.2)) {
                     showSearchDropdown = true
@@ -2621,7 +2605,6 @@ struct MacOSNavigation: View {
             .buttonStyle(.plain)
             .disabled(channelMatchCount == 0)
 
-            #if DISPATCHERPVR
             if !matchingGroups.isEmpty {
                 Divider().overlay(Theme.surfaceHighlight)
 
@@ -2652,7 +2635,6 @@ struct MacOSNavigation: View {
                     .buttonStyle(.plain)
                 }
             }
-            #endif
 
             Divider().overlay(Theme.surfaceHighlight)
 

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -504,10 +504,9 @@ struct IOSNavigation: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(Theme.accent)
             }
+            #endif
 
-            if !epgCache.channelProfiles.isEmpty || epgCache.channelGroups.contains(where: { group in
-                epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-            }) {
+            if !epgCache.channelProfiles.isEmpty || epgCache.hasPopulatedChannelGroups {
                 Button {
                     withAnimation(.easeInOut(duration: 0.25)) {
                         guideViewModel.showFilters.toggle()
@@ -520,7 +519,6 @@ struct IOSNavigation: View {
                         .foregroundStyle(guideViewModel.hasActiveFilters ? Theme.accent : Theme.textPrimary)
                 }
             }
-            #endif
         }
     }
 
@@ -627,9 +625,7 @@ struct IOSNavigation: View {
                             // Group sub-items (#158: NextPVR has groups too)
                             let prefs = UserPreferences.load()
                             if prefs.guideShowGroupsInSidebar {
-                                let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                                }
+                                let populatedGroups = epgCache.populatedChannelGroups
                                 ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
                                     sidebarGuideGroupSubRow(group: group)
                                 }
@@ -672,9 +668,7 @@ struct IOSNavigation: View {
                             // Group sub-items (#158: NextPVR has groups too)
                             let prefs = UserPreferences.load()
                             if prefs.guideShowGroupsInSidebar {
-                                let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                                }
+                                let populatedGroups = epgCache.populatedChannelGroups
                                 ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
                                     sidebarChannelGroupSubRow(group: group)
                                 }
@@ -1458,9 +1452,7 @@ struct TVOSNavigation: View {
                                     }
 
                                     if guideSidebarPreferences.guideShowGroupsInSidebar {
-                                        let populatedGroups = epgCache.channelGroups.filter { group in
-                                            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                                        }
+                                        let populatedGroups = epgCache.populatedChannelGroups
                                         ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                             tvOSSidebarSubRow(
                                                 label: group.name,
@@ -1524,9 +1516,7 @@ struct TVOSNavigation: View {
                                     }
 
                                     if guideSidebarPreferences.guideShowGroupsInSidebar {
-                                        let populatedGroups = epgCache.channelGroups.filter { group in
-                                            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                                        }
+                                        let populatedGroups = epgCache.populatedChannelGroups
                                         ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                             tvOSSidebarSubRow(
                                                 label: group.name,
@@ -2126,9 +2116,7 @@ struct MacOSNavigation: View {
                             macSidebarGuideAllRow()
 
                             if guideSidebarPreferences.guideShowGroupsInSidebar {
-                                let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                                }
+                                let populatedGroups = epgCache.populatedChannelGroups
                                 ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                     macSidebarGuideGroupSubRow(group: group)
                                 }
@@ -2161,9 +2149,7 @@ struct MacOSNavigation: View {
                             macSidebarChannelAllRow()
 
                             if guideSidebarPreferences.guideShowGroupsInSidebar {
-                                let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
-                                }
+                                let populatedGroups = epgCache.populatedChannelGroups
                                 ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                     macSidebarChannelGroupSubRow(group: group)
                                 }

--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -427,7 +427,7 @@ struct IOSNavigation: View {
                 let query = newValue.lowercased()
                 let groupsWithChannels = epgCache.channelGroups.filter { group in
                     group.name.lowercased().contains(query) &&
-                    epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                 }
                 matchingGroups = groupsWithChannels
                 #endif
@@ -513,7 +513,7 @@ struct IOSNavigation: View {
             }
 
             if !epgCache.channelProfiles.isEmpty || epgCache.channelGroups.contains(where: { group in
-                epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
             }) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.25)) {
@@ -614,11 +614,9 @@ struct IOSNavigation: View {
                         } else if tab == .guide {
                             // Guide header (tappable) + optional group sub-items
                             Button {
-                                #if DISPATCHERPVR
                                 appState.guideGroupFilter = nil
                                 appState.guideChannelFilter = ""
                                 appState.guideProfileFilter = nil
-                                #endif
                                 appState.selectedTab = .guide
                                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                                     isSidebarOpen = false
@@ -633,17 +631,18 @@ struct IOSNavigation: View {
                             }
                             .accessibilityIdentifier("tab-\(tab.rawValue)")
 
-                            // Group sub-items (Dispatcharr only)
-                            #if DISPATCHERPVR
+                            // Group sub-items (#158: NextPVR has groups too)
                             let prefs = UserPreferences.load()
                             if prefs.guideShowGroupsInSidebar {
                                 let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                                 }
                                 ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
                                     sidebarGuideGroupSubRow(group: group)
                                 }
                             }
+                            // Profile sub-items (Dispatcharr only)
+                            #if DISPATCHERPVR
                             if prefs.guideShowProfilesInSidebar {
                                 let populatedProfiles = epgCache.channelProfiles.filter { profile in
                                     epgCache.guideSidebarChannels.contains { profile.channels.contains($0.id) }
@@ -660,11 +659,9 @@ struct IOSNavigation: View {
                             // `guideShowGroupsInSidebar` / `guideShowProfilesInSidebar`
                             // preferences — no new settings are required (issue #105).
                             Button {
-                                #if DISPATCHERPVR
                                 appState.guideGroupFilter = nil
                                 appState.guideChannelFilter = ""
                                 appState.guideProfileFilter = nil
-                                #endif
                                 appState.selectedTab = .channels
                                 withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                                     isSidebarOpen = false
@@ -679,17 +676,18 @@ struct IOSNavigation: View {
                             }
                             .accessibilityIdentifier("tab-\(tab.rawValue)")
 
-                            // Group sub-items (Dispatcharr only)
-                            #if DISPATCHERPVR
+                            // Group sub-items (#158: NextPVR has groups too)
                             let prefs = UserPreferences.load()
                             if prefs.guideShowGroupsInSidebar {
                                 let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                                 }
                                 ForEach(populatedGroups.filter { prefs.guideGroupIds.isEmpty || prefs.guideGroupIds.contains($0.id) }) { group in
                                     sidebarChannelGroupSubRow(group: group)
                                 }
                             }
+                            // Profile sub-items (Dispatcharr only)
+                            #if DISPATCHERPVR
                             if prefs.guideShowProfilesInSidebar {
                                 let populatedProfiles = epgCache.channelProfiles.filter { profile in
                                     epgCache.guideSidebarChannels.contains { profile.channels.contains($0.id) }
@@ -884,13 +882,12 @@ struct IOSNavigation: View {
         .accessibilityIdentifier("topic-keyword-\(keyword)")
     }
 
-    #if DISPATCHERPVR
     private func sidebarGuideGroupSubRow(group: ChannelGroup) -> some View {
         let isSelected = appState.selectedTab == .guide && appState.guideGroupFilter == group.id
         return Button {
             appState.guideGroupFilter = group.id
-            appState.guideProfileFilter = nil
             appState.guideChannelFilter = ""
+            appState.guideProfileFilter = nil
             appState.selectedTab = .guide
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                 isSidebarOpen = false
@@ -914,6 +911,7 @@ struct IOSNavigation: View {
         .accessibilityIdentifier("guide-group-\(group.id)")
     }
 
+    #if DISPATCHERPVR
     private func sidebarGuideProfileSubRow(profile: ChannelProfile) -> some View {
         let isSelected = appState.selectedTab == .guide && appState.guideProfileFilter == profile.id
         return Button {
@@ -942,13 +940,14 @@ struct IOSNavigation: View {
         }
         .accessibilityIdentifier("guide-profile-\(profile.id)")
     }
+    #endif
 
     private func sidebarChannelGroupSubRow(group: ChannelGroup) -> some View {
         let isSelected = appState.selectedTab == .channels && appState.guideGroupFilter == group.id
         return Button {
             appState.guideGroupFilter = group.id
-            appState.guideProfileFilter = nil
             appState.guideChannelFilter = ""
+            appState.guideProfileFilter = nil
             appState.selectedTab = .channels
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                 isSidebarOpen = false
@@ -972,6 +971,7 @@ struct IOSNavigation: View {
         .accessibilityIdentifier("channel-group-\(group.id)")
     }
 
+    #if DISPATCHERPVR
     private func sidebarChannelProfileSubRow(profile: ChannelProfile) -> some View {
         let isSelected = appState.selectedTab == .channels && appState.guideProfileFilter == profile.id
         return Button {
@@ -1190,9 +1190,17 @@ struct TVOSNavigation: View {
     @EnvironmentObject private var client: PVRClient
     @EnvironmentObject private var epgCache: EPGCache
     @State private var sidebarEnabled = true
-    #if DISPATCHERPVR
     @State private var guideSidebarPreferences = UserPreferences.load()
-    #endif
+
+    /// Channel profiles are a Dispatcharr concept, so the profile half of the
+    /// guide/channels sub-menus is compiled out of the NextPVR build (#158).
+    private var guideSidebarShowsProfiles: Bool {
+        #if DISPATCHERPVR
+        return guideSidebarPreferences.guideShowProfilesInSidebar
+        #else
+        return false
+        #endif
+    }
     @FocusState private var focusedItem: TVSidebarItem?
 
     private let sidebarWidth: CGFloat = 440
@@ -1261,15 +1269,11 @@ struct TVOSNavigation: View {
         .onAppear {
             focusedItem = preferredSidebarFocusItem()
             appState.topicKeywords = UserPreferences.load().keywords
-            #if DISPATCHERPVR
             guideSidebarPreferences = UserPreferences.load()
-            #endif
         }
-        #if DISPATCHERPVR
         .onReceive(NotificationCenter.default.publisher(for: .preferencesDidSync)) { _ in
             guideSidebarPreferences = UserPreferences.load()
         }
-        #endif
         .onChange(of: focusedItem) { _, newItem in
             if newItem == nil {
                 // When sidebar loses focus, disable it so content can receive focus
@@ -1345,30 +1349,30 @@ struct TVOSNavigation: View {
             }
             return .topicManage
         case .guide:
-            #if DISPATCHERPVR
-            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarPreferences.guideShowProfilesInSidebar {
+            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarShowsProfiles {
                 if let groupId = appState.guideGroupFilter {
                     return .guideGroup(groupId)
                 }
+                #if DISPATCHERPVR
                 if let profileId = appState.guideProfileFilter {
                     return .guideProfile(profileId)
                 }
+                #endif
                 return .guideAll
             }
-            #endif
             return .tab(.guide)
         case .channels:
-            #if DISPATCHERPVR
-            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarPreferences.guideShowProfilesInSidebar {
+            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarShowsProfiles {
                 if let groupId = appState.guideGroupFilter {
                     return .channelGroup(groupId)
                 }
+                #if DISPATCHERPVR
                 if let profileId = appState.guideProfileFilter {
                     return .channelProfile(profileId)
                 }
+                #endif
                 return .channelAll
             }
-            #endif
             return .tab(.channels)
         default:
             return .tab(appState.selectedTab)
@@ -1449,8 +1453,7 @@ struct TVOSNavigation: View {
                                 ) { EmptyView() }
                             }
                         } else if tab == .guide {
-                            #if DISPATCHERPVR
-                            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarPreferences.guideShowProfilesInSidebar {
+                            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarShowsProfiles {
                                 // Guide section with an "All" row plus optional group/profile shortcuts.
                                 tvOSSidebarSection(icon: tab.icon, label: tab.label) {
                                     EmptyView()
@@ -1465,7 +1468,7 @@ struct TVOSNavigation: View {
 
                                     if guideSidebarPreferences.guideShowGroupsInSidebar {
                                         let populatedGroups = epgCache.channelGroups.filter { group in
-                                            epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                                            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                                         }
                                         ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                             tvOSSidebarSubRow(
@@ -1478,6 +1481,7 @@ struct TVOSNavigation: View {
                                         }
                                     }
 
+                                    #if DISPATCHERPVR
                                     if guideSidebarPreferences.guideShowProfilesInSidebar {
                                         let populatedProfiles = epgCache.channelProfiles.filter { profile in
                                             epgCache.guideSidebarChannels.contains { profile.channels.contains($0.id) }
@@ -1492,6 +1496,7 @@ struct TVOSNavigation: View {
                                             }
                                         }
                                     }
+                                    #endif
                                 }
                             } else {
                                 tvOSSidebarRow(
@@ -1509,27 +1514,13 @@ struct TVOSNavigation: View {
                                     focusedItem = nil
                                 } badge: { tvOSSidebarBadge(for: tab) }
                             }
-                            #else
-                            tvOSSidebarRow(
-                                icon: tab.icon,
-                                label: tab.label,
-                                item: .tab(tab),
-                                isSelected: appState.selectedTab == tab,
-                                isCompact: true
-                            ) {
-                                appState.selectedTab = tab
-                                sidebarEnabled = false
-                                focusedItem = nil
-                            } badge: { tvOSSidebarBadge(for: tab) }
-                            #endif
                         } else if tab == .channels {
                             // Channels section mirrors the guide's sub-menu UX
                             // (issue #105). Reuses the same group/profile filter
                             // state and the existing `guideShowGroupsInSidebar` /
                             // `guideShowProfilesInSidebar` preferences — no new
                             // settings are required.
-                            #if DISPATCHERPVR
-                            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarPreferences.guideShowProfilesInSidebar {
+                            if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarShowsProfiles {
                                 tvOSSidebarSection(icon: tab.icon, label: tab.label) {
                                     EmptyView()
                                 } content: {
@@ -1543,7 +1534,7 @@ struct TVOSNavigation: View {
 
                                     if guideSidebarPreferences.guideShowGroupsInSidebar {
                                         let populatedGroups = epgCache.channelGroups.filter { group in
-                                            epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                                            epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                                         }
                                         ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                             tvOSSidebarSubRow(
@@ -1556,6 +1547,7 @@ struct TVOSNavigation: View {
                                         }
                                     }
 
+                                    #if DISPATCHERPVR
                                     if guideSidebarPreferences.guideShowProfilesInSidebar {
                                         let populatedProfiles = epgCache.channelProfiles.filter { profile in
                                             epgCache.guideSidebarChannels.contains { profile.channels.contains($0.id) }
@@ -1570,6 +1562,7 @@ struct TVOSNavigation: View {
                                             }
                                         }
                                     }
+                                    #endif
                                 }
                             } else {
                                 tvOSSidebarRow(
@@ -1587,19 +1580,6 @@ struct TVOSNavigation: View {
                                     focusedItem = nil
                                 } badge: { tvOSSidebarBadge(for: tab) }
                             }
-                            #else
-                            tvOSSidebarRow(
-                                icon: tab.icon,
-                                label: tab.label,
-                                item: .tab(tab),
-                                isSelected: appState.selectedTab == tab,
-                                isCompact: true
-                            ) {
-                                appState.selectedTab = tab
-                                sidebarEnabled = false
-                                focusedItem = nil
-                            } badge: { tvOSSidebarBadge(for: tab) }
-                            #endif
                         } else {
                             tvOSSidebarRow(
                                 icon: tab.icon,
@@ -1742,7 +1722,6 @@ struct TVOSNavigation: View {
             case .topicManage:
                 appState.showingKeywordsEditor = true
                 appState.selectedTab = .topics
-            #if DISPATCHERPVR
             case .guideAll:
                 appState.guideGroupFilter = nil
                 appState.guideProfileFilter = nil
@@ -1753,11 +1732,13 @@ struct TVOSNavigation: View {
                 appState.guideProfileFilter = nil
                 appState.guideChannelFilter = ""
                 appState.selectedTab = .guide
+            #if DISPATCHERPVR
             case .guideProfile(let profileId):
                 appState.guideProfileFilter = profileId
                 appState.guideGroupFilter = nil
                 appState.guideChannelFilter = ""
                 appState.selectedTab = .guide
+            #endif
             case .channelAll:
                 appState.guideGroupFilter = nil
                 appState.guideProfileFilter = nil
@@ -1768,6 +1749,7 @@ struct TVOSNavigation: View {
                 appState.guideProfileFilter = nil
                 appState.guideChannelFilter = ""
                 appState.selectedTab = .channels
+            #if DISPATCHERPVR
             case .channelProfile(let profileId):
                 appState.guideProfileFilter = profileId
                 appState.guideGroupFilter = nil
@@ -1823,17 +1805,17 @@ struct TVOSNavigation: View {
             return "topic-keyword-\(keyword)"
         case .topicManage:
             return "topic-manage"
-        #if DISPATCHERPVR
         case .guideAll:
             return "guide-all"
         case .guideGroup(let groupId):
             return "guide-group-\(groupId)"
-        case .guideProfile(let profileId):
-            return "guide-profile-\(profileId)"
         case .channelAll:
             return "channel-all"
         case .channelGroup(let groupId):
             return "channel-group-\(groupId)"
+        #if DISPATCHERPVR
+        case .guideProfile(let profileId):
+            return "guide-profile-\(profileId)"
         case .channelProfile(let profileId):
             return "channel-profile-\(profileId)"
         #endif
@@ -1889,15 +1871,15 @@ enum TVSidebarItem: Hashable {
     case recordingsSeriesMore
     case topicKeyword(String)
     case topicManage
-    #if DISPATCHERPVR
     case guideAll
     case guideGroup(Int)
-    case guideProfile(Int)
     /// Channels-page sub-menu items (issue #105). Mirror the guide's
     /// sub-menu items but target the channels tab; selection writes to the
     /// same `guideGroupFilter` / `guideProfileFilter` state.
     case channelAll
     case channelGroup(Int)
+    #if DISPATCHERPVR
+    case guideProfile(Int)
     case channelProfile(Int)
     #endif
 }
@@ -1960,9 +1942,17 @@ struct MacOSNavigation: View {
     @State private var matchingGroups: [ChannelGroup] = []
     @State private var searchDebounceTask: Task<Void, Never>?
     @State private var lastSearchedText = ""
-    #if DISPATCHERPVR
     @State private var guideSidebarPreferences = UserPreferences.load()
-    #endif
+
+    /// Channel profiles are a Dispatcharr concept, so the profile half of the
+    /// guide/channels sub-menus is compiled out of the NextPVR build (#158).
+    private var guideSidebarShowsProfiles: Bool {
+        #if DISPATCHERPVR
+        return guideSidebarPreferences.guideShowProfilesInSidebar
+        #else
+        return false
+        #endif
+    }
 
     var body: some View {
         Group {
@@ -2069,7 +2059,7 @@ struct MacOSNavigation: View {
                 let query = newValue.lowercased()
                 let groupsWithChannels = epgCache.channelGroups.filter { group in
                     group.name.lowercased().contains(query) &&
-                    epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                 }
                 matchingGroups = groupsWithChannels
                 #endif
@@ -2089,16 +2079,12 @@ struct MacOSNavigation: View {
         }
         .onAppear {
             appState.topicKeywords = UserPreferences.load().keywords
-            #if DISPATCHERPVR
             guideSidebarPreferences = UserPreferences.load()
-            #endif
             Task { await computeTopicMatchCounts() }
         }
-        #if DISPATCHERPVR
         .onReceive(NotificationCenter.default.publisher(for: .preferencesDidSync)) { _ in
             guideSidebarPreferences = UserPreferences.load()
         }
-        #endif
         .onChange(of: appState.showingKeywordsEditor) { _ in
             if !appState.showingKeywordsEditor {
                 appState.topicKeywords = UserPreferences.load().keywords
@@ -2151,20 +2137,20 @@ struct MacOSNavigation: View {
                         macSidebarHeader(icon: tab.icon, label: tab.label)
                     }
                 } else if tab == .guide {
-                    #if DISPATCHERPVR
-                    if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarPreferences.guideShowProfilesInSidebar {
+                    if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarShowsProfiles {
                         Section {
                             macSidebarGuideAllRow()
 
                             if guideSidebarPreferences.guideShowGroupsInSidebar {
                                 let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                                 }
                                 ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                     macSidebarGuideGroupSubRow(group: group)
                                 }
                             }
 
+                            #if DISPATCHERPVR
                             if guideSidebarPreferences.guideShowProfilesInSidebar {
                                 let populatedProfiles = epgCache.channelProfiles.filter { profile in
                                     epgCache.guideSidebarChannels.contains { profile.channels.contains($0.id) }
@@ -2173,35 +2159,33 @@ struct MacOSNavigation: View {
                                     macSidebarGuideProfileSubRow(profile: profile)
                                 }
                             }
+                            #endif
                         } header: {
                             macSidebarHeader(icon: tab.icon, label: tab.label)
                         }
                     } else {
                         macSidebarRow(tab: tab)
                     }
-                    #else
-                    macSidebarRow(tab: tab)
-                    #endif
                 } else if tab == .channels {
                     // Channels section mirrors the guide's sub-menu UX
                     // (issue #105). Reuses the same group/profile filter
                     // state and the existing `guideShowGroupsInSidebar` /
                     // `guideShowProfilesInSidebar` preferences — no new
                     // settings are required.
-                    #if DISPATCHERPVR
-                    if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarPreferences.guideShowProfilesInSidebar {
+                    if guideSidebarPreferences.guideShowGroupsInSidebar || guideSidebarShowsProfiles {
                         Section {
                             macSidebarChannelAllRow()
 
                             if guideSidebarPreferences.guideShowGroupsInSidebar {
                                 let populatedGroups = epgCache.channelGroups.filter { group in
-                                    epgCache.guideSidebarChannels.contains { $0.groupId == group.id }
+                                    epgCache.guideSidebarChannels.contains { $0.isMember(ofGroup: group.id) }
                                 }
                                 ForEach(populatedGroups.filter { guideSidebarPreferences.guideGroupIds.isEmpty || guideSidebarPreferences.guideGroupIds.contains($0.id) }) { group in
                                     macSidebarChannelGroupSubRow(group: group)
                                 }
                             }
 
+                            #if DISPATCHERPVR
                             if guideSidebarPreferences.guideShowProfilesInSidebar {
                                 let populatedProfiles = epgCache.channelProfiles.filter { profile in
                                     epgCache.guideSidebarChannels.contains { profile.channels.contains($0.id) }
@@ -2210,15 +2194,13 @@ struct MacOSNavigation: View {
                                     macSidebarChannelProfileSubRow(profile: profile)
                                 }
                             }
+                            #endif
                         } header: {
                             macSidebarHeader(icon: tab.icon, label: tab.label)
                         }
                     } else {
                         macSidebarRow(tab: tab)
                     }
-                    #else
-                    macSidebarRow(tab: tab)
-                    #endif
                 } else {
                     macSidebarRow(tab: tab)
                 }
@@ -2243,13 +2225,11 @@ struct MacOSNavigation: View {
     private func macSidebarRow(tab: Tab) -> some View {
         let isSelected = appState.selectedTab == tab
         return Button {
-            #if DISPATCHERPVR
             if tab == .guide {
                 appState.guideGroupFilter = nil
                 appState.guideProfileFilter = nil
                 appState.guideChannelFilter = ""
             }
-            #endif
             appState.selectedTab = tab
         } label: {
             HStack(spacing: 10) {
@@ -2352,7 +2332,6 @@ struct MacOSNavigation: View {
         .accessibilityIdentifier("recordings-series-menu")
     }
 
-    #if DISPATCHERPVR
     private func macSidebarGuideAllRow() -> some View {
         let isSelected = appState.selectedTab == .guide && appState.guideGroupFilter == nil && appState.guideProfileFilter == nil
         return Button {
@@ -2405,6 +2384,7 @@ struct MacOSNavigation: View {
         .accessibilityIdentifier("guide-group-\(group.id)")
     }
 
+    #if DISPATCHERPVR
     private func macSidebarGuideProfileSubRow(profile: ChannelProfile) -> some View {
         let isSelected = appState.selectedTab == .guide && appState.guideProfileFilter == profile.id
         return Button {
@@ -2430,6 +2410,7 @@ struct MacOSNavigation: View {
         .buttonStyle(.plain)
         .accessibilityIdentifier("guide-profile-\(profile.id)")
     }
+    #endif
 
     private func macSidebarChannelAllRow() -> some View {
         let isSelected = appState.selectedTab == .channels && appState.guideGroupFilter == nil && appState.guideProfileFilter == nil
@@ -2483,6 +2464,7 @@ struct MacOSNavigation: View {
         .accessibilityIdentifier("channel-group-\(group.id)")
     }
 
+    #if DISPATCHERPVR
     private func macSidebarChannelProfileSubRow(profile: ChannelProfile) -> some View {
         let isSelected = appState.selectedTab == .channels && appState.guideProfileFilter == profile.id
         return Button {

--- a/NexusPVRTests/ChannelGroupCatalogTests.swift
+++ b/NexusPVRTests/ChannelGroupCatalogTests.swift
@@ -1,0 +1,77 @@
+//
+//  ChannelGroupCatalogTests.swift
+//  NexusPVRTests
+//
+//  Tests for the group/membership catalogue shared by the cache (#158).
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct ChannelGroupCatalogTests {
+
+    private let sports = ChannelGroup(name: "Sports")
+    private let news = ChannelGroup(name: "News")
+    private let empty = ChannelGroup(name: "Empty")
+
+    @Test("Membership is inverted from each group's channel ids")
+    func invertsMembership() {
+        let catalog = ChannelGroupCatalog(
+            groups: [sports, news],
+            channelIdsByGroupId: [sports.id: [1, 2], news.id: [3]]
+        )
+        #expect(catalog.membership[1] == [sports.id])
+        #expect(catalog.membership[2] == [sports.id])
+        #expect(catalog.membership[3] == [news.id])
+    }
+
+    @Test("A channel in several groups keeps every membership")
+    func multiGroupMembership() {
+        let catalog = ChannelGroupCatalog(
+            groups: [sports, news],
+            channelIdsByGroupId: [sports.id: [1], news.id: [1]]
+        )
+        #expect(catalog.membership[1] == [sports.id, news.id])
+    }
+
+    @Test("Duplicate channel ids inside a group collapse")
+    func duplicateMembershipCollapses() {
+        let catalog = ChannelGroupCatalog(
+            groups: [sports],
+            channelIdsByGroupId: [sports.id: [1, 1, 1]]
+        )
+        #expect(catalog.membership[1] == [sports.id])
+    }
+
+    @Test("An empty group is still listed but owns no channels")
+    func emptyGroupIsListed() {
+        let catalog = ChannelGroupCatalog(
+            groups: [sports, empty],
+            channelIdsByGroupId: [sports.id: [1], empty.id: []]
+        )
+        #expect(catalog.groups.count == 2)
+        #expect(catalog.channelIds(inGroup: empty.id).isEmpty)
+        #expect(catalog.channelIds(inGroup: sports.id) == [1])
+    }
+
+    @Test("Channel ids for a group the server never reported are empty")
+    func unknownGroupHasNoChannels() {
+        let catalog = ChannelGroupCatalog(groups: [sports], channelIdsByGroupId: [sports.id: [1]])
+        #expect(catalog.channelIds(inGroup: news.id).isEmpty)
+    }
+
+    @Test("The empty catalogue reports itself as empty")
+    func emptyCatalogue() {
+        #expect(ChannelGroupCatalog.empty.isEmpty)
+        #expect(ChannelGroupCatalog.empty.groups.isEmpty)
+        #expect(ChannelGroupCatalog.empty.membership.isEmpty)
+    }
+
+    @Test("Membership for groups with no reported ids is absent, not empty")
+    func missingGroupEntry() {
+        let catalog = ChannelGroupCatalog(groups: [sports, news], channelIdsByGroupId: [sports.id: [1]])
+        #expect(catalog.membership[1] == [sports.id])
+        #expect(catalog.membership.count == 1)
+    }
+}

--- a/NexusPVRTests/ChannelGroupListResponseTests.swift
+++ b/NexusPVRTests/ChannelGroupListResponseTests.swift
@@ -1,0 +1,66 @@
+//
+//  ChannelGroupListResponseTests.swift
+//  NexusPVRTests
+//
+//  Tests for decoding NextPVR's `channel.groups` payload (#158).
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct ChannelGroupListResponseTests {
+
+    private func decode(_ json: String) throws -> ChannelGroupListResponse {
+        try JSONDecoder().decode(ChannelGroupListResponse.self, from: Data(json.utf8))
+    }
+
+    @Test("Decodes a bare array of group names")
+    func decodesStringArray() throws {
+        let response = try decode(#"{"groups": ["Sports", "News", "Kids"]}"#)
+        #expect(response.groupNames == ["Sports", "News", "Kids"])
+    }
+
+    @Test("Decodes group objects carrying a name field")
+    func decodesObjectArray() throws {
+        let response = try decode(#"{"groups": [{"name": "Sports"}, {"name": "News"}]}"#)
+        #expect(response.groupNames == ["Sports", "News"])
+    }
+
+    @Test("Decodes group objects using the groupName alias")
+    func decodesGroupNameAlias() throws {
+        let response = try decode(#"{"groups": [{"groupName": "Movies"}, {"group": "Local"}]}"#)
+        #expect(response.groupNames == ["Movies", "Local"])
+    }
+
+    @Test("Ignores extra fields on group objects")
+    func ignoresExtraFields() throws {
+        let response = try decode(#"{"groups": [{"name": "Sports", "count": 12, "id": 3}]}"#)
+        #expect(response.groupNames == ["Sports"])
+    }
+
+    @Test("Missing groups key decodes to no groups")
+    func missingGroupsKey() throws {
+        let response = try decode(#"{"stat": "ok"}"#)
+        #expect(response.groupNames.isEmpty)
+    }
+
+    @Test("Empty groups array decodes to no groups")
+    func emptyGroupsArray() throws {
+        let response = try decode(#"{"groups": []}"#)
+        #expect(response.groupNames.isEmpty)
+    }
+
+    @Test("Blank and duplicate names are dropped")
+    func trimsAndDeduplicates() throws {
+        let response = try decode(#"{"groups": ["  Sports  ", "", "   ", "Sports", "News"]}"#)
+        #expect(response.groupNames == ["Sports", "News"])
+    }
+
+    @Test("A group entry without any name fails the decode")
+    func entryWithoutNameThrows() {
+        #expect(throws: (any Error).self) {
+            try decode(#"{"groups": [{"count": 3}]}"#)
+        }
+    }
+}

--- a/NexusPVRTests/ChannelGroupTests.swift
+++ b/NexusPVRTests/ChannelGroupTests.swift
@@ -1,0 +1,66 @@
+//
+//  ChannelGroupTests.swift
+//  NexusPVRTests
+//
+//  Tests for the name-based channel group identity NextPVR needs (#158).
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct ChannelGroupTests {
+
+    @Test("Group built from a name keeps the name and derives its id from it")
+    func nameInitDerivesId() {
+        let group = ChannelGroup(name: "Sports")
+        #expect(group.name == "Sports")
+        #expect(group.id == ChannelGroup.stableId(forName: "Sports"))
+    }
+
+    @Test("Stable ids are deterministic for the same name")
+    func stableIdIsDeterministic() {
+        // The ids are persisted in UserPreferences and synced via iCloud, so
+        // they must not vary between runs the way String.hashValue does.
+        #expect(ChannelGroup.stableId(forName: "News") == ChannelGroup.stableId(forName: "News"))
+        #expect(ChannelGroup.stableId(forName: "News") == 1_274_284_134)
+        #expect(ChannelGroup.stableId(forName: "Kids") == 889_456_028)
+    }
+
+    @Test("Different names get different ids")
+    func distinctNamesDistinctIds() {
+        let names = ["Sports", "News", "Kids", "Movies", "Local", "Français", ""]
+        let ids = Set(names.map(ChannelGroup.stableId(forName:)))
+        #expect(ids.count == names.count)
+    }
+
+    @Test("Stable ids are non-negative and fit in Int32")
+    func stableIdRange() {
+        for name in ["Sports", "News", "A very long channel group name ☃️", "z"] {
+            let id = ChannelGroup.stableId(forName: name)
+            #expect(id >= 0)
+            #expect(id <= Int(Int32.max))
+        }
+    }
+
+    @Test("Group name is case and whitespace sensitive")
+    func namesAreDistinctByExactSpelling() {
+        #expect(ChannelGroup.stableId(forName: "Sports") != ChannelGroup.stableId(forName: "sports"))
+        #expect(ChannelGroup.stableId(forName: "Sports") != ChannelGroup.stableId(forName: "Sports "))
+    }
+
+    @Test("Explicit id initializer is unchanged for integer-id backends")
+    func explicitIdInit() {
+        let group = ChannelGroup(id: 7, name: "Entertainment")
+        #expect(group.id == 7)
+        #expect(group.name == "Entertainment")
+    }
+
+    @Test("Group decodes Dispatcharr's integer-id payload")
+    func decodesIntegerIdPayload() throws {
+        let json = #"{"id": 12, "name": "Documentary"}"#
+        let group = try JSONDecoder().decode(ChannelGroup.self, from: Data(json.utf8))
+        #expect(group.id == 12)
+        #expect(group.name == "Documentary")
+    }
+}

--- a/NexusPVRTests/ChannelTests.swift
+++ b/NexusPVRTests/ChannelTests.swift
@@ -108,3 +108,69 @@ struct ChannelTests {
         #expect(ch.catchupDays == 0)
     }
 }
+
+// MARK: - Group membership (#158)
+
+struct ChannelGroupMembershipTests {
+
+    @Test("A channel with no group data belongs to nothing")
+    func noGroups() {
+        let ch = Channel(id: 1, name: "A", number: 1)
+        #expect(ch.groupIds.isEmpty)
+        #expect(ch.isMember(ofGroup: 10) == false)
+    }
+
+    @Test("The single Dispatcharr groupId still counts as membership")
+    func singleGroupIdIsMembership() {
+        let ch = Channel(id: 1, name: "A", number: 1, groupId: 10)
+        #expect(ch.isMember(ofGroup: 10))
+        #expect(ch.isMember(ofGroup: 11) == false)
+    }
+
+    @Test("Multi-group membership matches any of the channel's groups")
+    func multiGroupMembership() {
+        let ch = Channel(id: 1, name: "A", number: 1, groupIds: [10, 20])
+        #expect(ch.isMember(ofGroup: 10))
+        #expect(ch.isMember(ofGroup: 20))
+        #expect(ch.isMember(ofGroup: 30) == false)
+    }
+
+    @Test("withGroupIds replaces memberships and keeps every other field")
+    func withGroupIdsPreservesFields() {
+        let ch = Channel(
+            id: 7,
+            name: "Sports HD",
+            number: 42,
+            hasIcon: true,
+            streamURL: "http://host/stream.ts",
+            groupIds: [1],
+            isCatchup: true,
+            catchupDays: 3
+        )
+        let updated = ch.withGroupIds([2, 3])
+        #expect(updated.groupIds == [2, 3])
+        #expect(updated.id == 7)
+        #expect(updated.name == "Sports HD")
+        #expect(updated.number == 42)
+        #expect(updated.hasIcon)
+        #expect(updated.streamURL == "http://host/stream.ts")
+        #expect(updated.isCatchup)
+        #expect(updated.catchupDays == 3)
+    }
+
+    @Test("Decoded NextPVR channels start with no group memberships")
+    func decodedChannelHasNoGroups() throws {
+        let json = #"{"channelId": 1, "channelName": "A"}"#
+        let ch = try JSONDecoder().decode(Channel.self, from: Data(json.utf8))
+        #expect(ch.groupId == nil)
+        #expect(ch.groupIds.isEmpty)
+    }
+
+    @Test("withCatchup carries group memberships through")
+    func withCatchupPreservesGroups() {
+        let ch = Channel(id: 1, name: "A", number: 1, groupId: 5, groupIds: [6])
+        let updated = ch.withCatchup(isCatchup: true, catchupDays: 2)
+        #expect(updated.groupId == 5)
+        #expect(updated.groupIds == [6])
+    }
+}

--- a/NexusPVRTests/EPGCacheTests.swift
+++ b/NexusPVRTests/EPGCacheTests.swift
@@ -206,6 +206,65 @@ struct EPGCacheTests {
         #expect(cache.channels(inGroup: nil).count == 3)
     }
 
+    // MARK: - Group search (sidebar dropdown, #158)
+
+    private var searchGroups: [ChannelGroup] {
+        [ChannelGroup(name: "Sports"), ChannelGroup(name: "Sports Extra"), ChannelGroup(name: "News"), ChannelGroup(name: "Empty")]
+    }
+
+    private var searchChannels: [Channel] {
+        [
+            Channel(id: 1, name: "A", number: 1, groupIds: [ChannelGroup.stableId(forName: "Sports")]),
+            Channel(id: 2, name: "B", number: 2, groupIds: [ChannelGroup.stableId(forName: "Sports Extra")]),
+            Channel(id: 3, name: "C", number: 3, groupIds: [ChannelGroup.stableId(forName: "News")])
+        ]
+    }
+
+    @Test("Group search matches every group whose name contains the query")
+    func groupSearchMatchesByName() {
+        let matches = EPGCache.channelGroups(searchGroups, matching: "sport", in: searchChannels)
+        #expect(matches.map(\.name) == ["Sports", "Sports Extra"])
+    }
+
+    @Test("Group search is case-insensitive")
+    func groupSearchIgnoresCase() {
+        let matches = EPGCache.channelGroups(searchGroups, matching: "NEWS", in: searchChannels)
+        #expect(matches.map(\.name) == ["News"])
+    }
+
+    @Test("Group search hides groups with no channels")
+    func groupSearchHidesEmptyGroups() {
+        let matches = EPGCache.channelGroups(searchGroups, matching: "empty", in: searchChannels)
+        #expect(matches.isEmpty)
+    }
+
+    @Test("An empty query matches no groups rather than all of them")
+    func groupSearchEmptyQuery() {
+        #expect(EPGCache.channelGroups(searchGroups, matching: "", in: searchChannels).isEmpty)
+    }
+
+    @Test("Group search finds nothing when the server reported no groups")
+    func groupSearchWithoutGroups() {
+        #expect(EPGCache.channelGroups([], matching: "sport", in: searchChannels).isEmpty)
+    }
+
+    @Test("Group search counts Dispatcharr's single-groupId membership too")
+    func groupSearchMatchesLegacyGroupId() {
+        let group = ChannelGroup(id: 10, name: "Movies")
+        let channels = [Channel(id: 1, name: "A", number: 1, groupId: 10)]
+        #expect(EPGCache.channelGroups([group], matching: "mov", in: channels).map(\.id) == [10])
+    }
+
+    @Test("Group search on the cache reads the unfiltered sidebar snapshot")
+    func groupSearchUsesSidebarSnapshot() {
+        let cache = EPGCache()
+        // guideSidebarChannels is only populated by a load, so an untouched
+        // cache must not surface groups it cannot back with channels.
+        cache.channelGroups = searchGroups
+        cache.visibleChannels = searchChannels
+        #expect(cache.channelGroups(matching: "sport").isEmpty)
+    }
+
     #if !DISPATCHERPVR
     private func makeUngroupedChannels() -> [Channel] {
         [

--- a/NexusPVRTests/EPGCacheTests.swift
+++ b/NexusPVRTests/EPGCacheTests.swift
@@ -190,6 +190,121 @@ struct EPGCacheTests {
         #expect(cache.channels(inGroup: 99).isEmpty)
     }
 
+    // MARK: - Name-based channel groups (#158)
+
+    @Test("channels(inGroup:) matches multi-group membership")
+    func channelsInGroupMatchesGroupIds() {
+        let cache = EPGCache()
+        cache.visibleChannels = [
+            Channel(id: 1, name: "A", number: 1, groupIds: [30, 40]),
+            Channel(id: 2, name: "B", number: 2, groupIds: [40]),
+            Channel(id: 3, name: "C", number: 3)
+        ]
+        #expect(cache.channels(inGroup: 30).map(\.id) == [1])
+        #expect(cache.channels(inGroup: 40).map(\.id) == [1, 2])
+        #expect(cache.channels(inGroup: 50).isEmpty)
+        #expect(cache.channels(inGroup: nil).count == 3)
+    }
+
+    #if !DISPATCHERPVR
+    private func makeUngroupedChannels() -> [Channel] {
+        [
+            Channel(id: 1, name: "Sports One", number: 1),
+            Channel(id: 2, name: "News One", number: 2),
+            Channel(id: 3, name: "Movie One", number: 3)
+        ]
+    }
+
+    private func populate(_ cache: EPGCache, with channels: [Channel]) {
+        cache.channels = channels
+        cache.visibleChannels = channels
+        cache.applyChannelGroups(.empty)
+    }
+
+    @Test("applyChannelGroups publishes groups and stamps membership")
+    func applyChannelGroupsStampsMembership() {
+        let sports = ChannelGroup(name: "Sports")
+        let news = ChannelGroup(name: "News")
+        let cache = EPGCache()
+        populate(cache, with: makeUngroupedChannels())
+
+        cache.applyChannelGroups(
+            ChannelGroupCatalog(
+                groups: [sports, news],
+                channelIdsByGroupId: [sports.id: [1, 2], news.id: [2]]
+            )
+        )
+
+        #expect(cache.channelGroups.map(\.name) == ["Sports", "News"])
+        #expect(cache.channels(inGroup: sports.id).map(\.id) == [1, 2])
+        #expect(cache.channels(inGroup: news.id).map(\.id) == [2])
+        #expect(cache.channelMap[2]?.groupIds == [sports.id, news.id])
+    }
+
+    @Test("applyChannelGroups keeps the unfiltered channel catalogue intact")
+    func applyChannelGroupsKeepsAllChannels() {
+        let sports = ChannelGroup(name: "Sports")
+        let cache = EPGCache()
+        populate(cache, with: makeUngroupedChannels())
+
+        cache.applyChannelGroups(
+            ChannelGroupCatalog(groups: [sports], channelIdsByGroupId: [sports.id: [1]])
+        )
+
+        #expect(cache.channels.count == 3)
+        #expect(cache.visibleChannels.count == 3)
+        #expect(cache.channels(inGroup: nil).count == 3)
+    }
+
+    @Test("An empty catalogue leaves the all-channel view working")
+    func emptyCatalogueFallsBackToAllChannels() {
+        let cache = EPGCache()
+        populate(cache, with: makeUngroupedChannels())
+
+        cache.applyChannelGroups(.empty)
+
+        #expect(cache.channelGroups.isEmpty)
+        #expect(cache.channels(inGroup: nil).count == 3)
+        #expect(cache.channels.allSatisfy { $0.groupIds.isEmpty })
+    }
+
+    @Test("Re-applying groups replaces memberships removed server-side")
+    func reapplyingGroupsDropsStaleMembership() {
+        let sports = ChannelGroup(name: "Sports")
+        let news = ChannelGroup(name: "News")
+        let cache = EPGCache()
+        populate(cache, with: makeUngroupedChannels())
+
+        cache.applyChannelGroups(
+            ChannelGroupCatalog(groups: [sports, news], channelIdsByGroupId: [sports.id: [1, 2], news.id: [2]])
+        )
+        // A refresh finds channel 2 moved out of Sports and News deleted.
+        cache.applyChannelGroups(
+            ChannelGroupCatalog(groups: [sports], channelIdsByGroupId: [sports.id: [1]])
+        )
+
+        #expect(cache.channelGroups.map(\.name) == ["Sports"])
+        #expect(cache.channels(inGroup: sports.id).map(\.id) == [1])
+        #expect(cache.channels(inGroup: news.id).isEmpty)
+        #expect(cache.channelMap[2]?.groupIds.isEmpty == true)
+    }
+
+    @Test("Groups reported with no channels stay listed but match nothing")
+    func emptyGroupMatchesNoChannels() {
+        let empty = ChannelGroup(name: "Empty")
+        let cache = EPGCache()
+        populate(cache, with: makeUngroupedChannels())
+
+        cache.applyChannelGroups(
+            ChannelGroupCatalog(groups: [empty], channelIdsByGroupId: [empty.id: []])
+        )
+
+        #expect(cache.channelGroups.count == 1)
+        #expect(cache.channels(inGroup: empty.id).isEmpty)
+    }
+
+    #endif
+
     // MARK: - Program Access
 
     @Test("earliestProgramDate finds the oldest EPG entry across channels")

--- a/NexusPVRTests/EPGCacheTests.swift
+++ b/NexusPVRTests/EPGCacheTests.swift
@@ -220,6 +220,32 @@ struct EPGCacheTests {
         ]
     }
 
+    @Test("Populated groups exclude groups with no channels")
+    func populatedGroupsExcludesEmpty() {
+        let groups = EPGCache.channelGroups(searchGroups, populatedIn: searchChannels)
+        #expect(groups.map(\.name) == ["Sports", "Sports Extra", "News"])
+    }
+
+    @Test("Populated groups preserve the server's order")
+    func populatedGroupsKeepOrder() {
+        let reversed: [ChannelGroup] = searchGroups.reversed()
+        let groups = EPGCache.channelGroups(reversed, populatedIn: searchChannels)
+        #expect(groups.map(\.name) == ["News", "Sports Extra", "Sports"])
+    }
+
+    @Test("Populated groups are empty when no channel has any membership")
+    func populatedGroupsWithoutMembership() {
+        let channels = [Channel(id: 1, name: "A", number: 1)]
+        #expect(EPGCache.channelGroups(searchGroups, populatedIn: channels).isEmpty)
+    }
+
+    @Test("Populated groups count Dispatcharr's single-groupId membership")
+    func populatedGroupsMatchLegacyGroupId() {
+        let group = ChannelGroup(id: 10, name: "Movies")
+        let channels = [Channel(id: 1, name: "A", number: 1, groupId: 10)]
+        #expect(EPGCache.channelGroups([group], populatedIn: channels).map(\.id) == [10])
+    }
+
     @Test("Group search matches every group whose name contains the query")
     func groupSearchMatchesByName() {
         let matches = EPGCache.channelGroups(searchGroups, matching: "sport", in: searchChannels)

--- a/NexusPVRTests/GuideViewModelTests.swift
+++ b/NexusPVRTests/GuideViewModelTests.swift
@@ -348,6 +348,77 @@ struct GuideViewModelTests {
         #expect(vm.channels.count == 1)
     }
 
+    // MARK: - Group filtering (#158)
+
+    @Test("Selecting a group narrows the guide to that group's channels")
+    func groupFilterNarrowsChannels() {
+        let sports = ChannelGroup(name: "Sports")
+        let news = ChannelGroup(name: "News")
+        let cache = EPGCache()
+        cache.visibleChannels = [
+            Channel(id: 1, name: "Sports One", number: 1, groupIds: [sports.id]),
+            Channel(id: 2, name: "Both", number: 2, groupIds: [sports.id, news.id]),
+            Channel(id: 3, name: "News One", number: 3, groupIds: [news.id])
+        ]
+        let vm = GuideViewModel()
+        vm.epgCache = cache
+
+        vm.selectedGroupId = sports.id
+        #expect(vm.hasActiveFilters)
+        #expect(vm.channels.map(\.id) == [1, 2])
+
+        vm.selectedGroupId = news.id
+        #expect(vm.channels.map(\.id) == [2, 3])
+    }
+
+    @Test("Clearing the group filter restores every channel")
+    func clearingGroupFilterRestoresAllChannels() {
+        let sports = ChannelGroup(name: "Sports")
+        let cache = EPGCache()
+        cache.visibleChannels = [
+            Channel(id: 1, name: "Sports One", number: 1, groupIds: [sports.id]),
+            Channel(id: 2, name: "Ungrouped", number: 2)
+        ]
+        let vm = GuideViewModel()
+        vm.epgCache = cache
+
+        vm.selectedGroupId = sports.id
+        #expect(vm.channels.count == 1)
+
+        vm.selectedGroupId = nil
+        #expect(vm.hasActiveFilters == false)
+        #expect(vm.channels.count == 2)
+    }
+
+    @Test("A group with no channels shows an empty guide rather than everything")
+    func emptyGroupShowsNoChannels() {
+        let empty = ChannelGroup(name: "Empty")
+        let cache = EPGCache()
+        cache.visibleChannels = [Channel(id: 1, name: "A", number: 1)]
+        let vm = GuideViewModel()
+        vm.epgCache = cache
+
+        vm.selectedGroupId = empty.id
+        #expect(vm.channels.isEmpty)
+    }
+
+    @Test("Channel search applies on top of the group filter")
+    func searchCombinesWithGroupFilter() {
+        let sports = ChannelGroup(name: "Sports")
+        let cache = EPGCache()
+        cache.visibleChannels = [
+            Channel(id: 1, name: "Hockey", number: 1, groupIds: [sports.id]),
+            Channel(id: 2, name: "Soccer", number: 2, groupIds: [sports.id]),
+            Channel(id: 3, name: "Hockey Classics", number: 3)
+        ]
+        let vm = GuideViewModel()
+        vm.epgCache = cache
+        vm.selectedGroupId = sports.id
+        vm.channelSearchText = "hockey"
+
+        #expect(vm.channels.map(\.id) == [1])
+    }
+
     // MARK: - updateKeywordMatches
 
     @Test("updateKeywordMatches clears the set when keywords are empty")

--- a/NexusPVRTests/UserPreferencesTests.swift
+++ b/NexusPVRTests/UserPreferencesTests.swift
@@ -201,6 +201,51 @@ struct UserPreferencesTests {
         #endif
     }
 
+    // MARK: - Guide group sidebar preferences (#158)
+
+    @Test("Guide group sidebar preferences survive a Codable round-trip")
+    func guideGroupPreferencesRoundTrip() throws {
+        var prefs = UserPreferences()
+        prefs.guideShowGroupsInSidebar = true
+        prefs.guideGroupIds = [
+            ChannelGroup.stableId(forName: "Sports"),
+            ChannelGroup.stableId(forName: "News")
+        ]
+
+        let decoded = try JSONDecoder().decode(
+            UserPreferences.self,
+            from: try JSONEncoder().encode(prefs)
+        )
+
+        #expect(decoded.guideShowGroupsInSidebar)
+        #expect(decoded.guideGroupIds == prefs.guideGroupIds)
+    }
+
+    @Test("Preferences saved before the group feature decode with defaults")
+    func guideGroupPreferencesBackwardCompatible() throws {
+        // A payload from a build that never wrote the group keys.
+        let json = #"{"keywords": ["news"], "seekBackwardSeconds": 10}"#
+        let decoded = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+
+        #expect(decoded.guideShowGroupsInSidebar == false)
+        #expect(decoded.guideGroupIds.isEmpty)
+    }
+
+    @Test("Name-derived group ids round-trip through JSON unchanged")
+    func nameDerivedGroupIdsSurviveEncoding() throws {
+        let ids = ["Sports", "News", "Kids", "Documentary & Lifestyle"]
+            .map(ChannelGroup.stableId(forName:))
+        var prefs = UserPreferences()
+        prefs.guideGroupIds = ids
+
+        let decoded = try JSONDecoder().decode(
+            UserPreferences.self,
+            from: try JSONEncoder().encode(prefs)
+        )
+
+        #expect(decoded.guideGroupIds == ids)
+    }
+
     @Test("resolvePersistence prefers local when both timestamps are distantPast")
     func resolve_tieGoesToLocal() {
         var local = UserPreferences()

--- a/mock-server-nextpvr/server.js
+++ b/mock-server-nextpvr/server.js
@@ -98,6 +98,21 @@ function generateChannels(n) {
   return channels;
 }
 
+// Spread the channels over a handful of named groups, leaving one group empty
+// and one channel in two groups so clients exercise both edge cases.
+function generateChannelGroups(channels) {
+  const names = ["Sports", "News", "Movies", "Kids", "Empty Group"];
+  const groups = names.map((name) => ({ name, channelIds: [] }));
+  channels.forEach((channel, index) => {
+    groups[index % (names.length - 1)].channelIds.push(channel.channelId);
+  });
+  if (channels.length > 1) {
+    // Duplicate membership: the first channel also sits in News.
+    groups[1].channelIds.unshift(channels[0].channelId);
+  }
+  return groups;
+}
+
 function generateShowName(genre, channelName) {
   const adj = pick(SHOW_ADJECTIVES);
   const noun = pick(SHOW_NOUNS);
@@ -397,8 +412,22 @@ function handleRequest(req, res) {
     return json(res, { stat: "fail", error: "Not authenticated" }, 401);
   }
 
-  // -- Channel list --
+  // -- Channel groups (#158) --
+  // NextPVR keys groups by name; membership comes back through
+  // channel.list&group_id=<name>.
+  if (method === "channel.groups") {
+    return json(res, { groups: CHANNEL_GROUPS.map((g) => ({ name: g.name })) });
+  }
+
+  // -- Channel list (optionally narrowed to one group) --
   if (method === "channel.list") {
+    const groupName = url.searchParams.get("group_id");
+    if (groupName) {
+      const group = CHANNEL_GROUPS.find((g) => g.name === groupName);
+      if (!group) return json(res, { channels: [] });
+      const ids = new Set(group.channelIds);
+      return json(res, { channels: CHANNELS.filter((c) => ids.has(c.channelId)) });
+    }
     return json(res, { channels: CHANNELS });
   }
 
@@ -620,6 +649,7 @@ function parseArgs() {
 
 console.log(`Generating ${NUM_CHANNELS} channels...`);
 const CHANNELS = generateChannels(NUM_CHANNELS);
+const CHANNEL_GROUPS = generateChannelGroups(CHANNELS);
 
 console.log(`Generating EPG data...`);
 const PROGRAMS_BY_CHANNEL = generateEPG(CHANNELS);
@@ -633,6 +663,7 @@ const server = http.createServer(handleRequest);
 server.listen(PORT, "::", () => {
   console.log(`\nMock NextPVR server running on http://0.0.0.0:${PORT}`);
   console.log(`  Channels:    ${CHANNELS.length}`);
+  console.log(`  Groups:      ${CHANNEL_GROUPS.length}`);
   console.log(`  Programs:    ${totalPrograms}`);
   console.log(`  Recordings:  ${RECORDINGS.length}`);
   console.log(`  Auth:        any PIN accepted`);


### PR DESCRIPTION
Closes #158.

NextPVR users with custom channel groups (News, Sports, Kids…) now get the same opt-in sidebar sub-menu and settings workflow Dispatcharr already had, on iOS, tvOS and macOS. Existing Dispatcharr group/profile behavior is unchanged.

## Group identity

NextPVR keys groups by **name**: `channel.groups` lists them and `channel.list&group_id=<name>` returns that group's channels (confirmed against [kodi-pvr/pvr.nextpvr](https://github.com/kodi-pvr/pvr.nextpvr/blob/Piers/src/Channels.cpp), the reference API consumer). The shared sidebar/filter/preference plumbing is keyed on `Int`, so `ChannelGroup(name:)` derives the id from a deterministic FNV-1a hash of the name — stable across launches, devices and iCloud sync, unlike `String.hashValue`. `UserPreferences` therefore needs no change and stays backward compatible.

NextPVR groups are also many-to-many, which the single Dispatcharr `Channel.groupId` can't express, so `Channel` gains `groupIds: [Int]` plus `isMember(ofGroup:)`; every shared group predicate now goes through it. Dispatcharr's `groupId` path is untouched.

## Changes

- **`NextPVRClient.getChannelGroupCatalog()`** — loads the group list, then resolves membership with capped-concurrency `channel.list&group_id=` requests. An unsupported, failing or group-less server yields an empty catalogue instead of breaking the channel/EPG load.
- **`ChannelGroupListResponse`** — tolerates either payload shape a NextPVR build may emit (`["Sports"]` or `[{"name":"Sports"}]`, plus `group`/`groupName` aliases); a missing `groups` key decodes to no groups. NextPVR's JSON serialization is hand-written per method and undocumented, hence the deliberately tolerant decoder.
- **`EPGCache`** — discovers groups in the background after first paint (mirroring the Dispatcharr catch-up enrichment) on both load and refresh, so the grid is never delayed and server-side group edits appear on pull-to-refresh.
- **Sidebar / Settings** — the group half of the Guide and Channels sub-rows and of the Guide settings section is now shared across brands; the profile half stays compiled out for NextPVR behind a `guideSidebarShowsProfiles` helper. Accessibility identifiers (`guide-group-<id>`, `channel-group-<id>`) are unchanged.
- **`mock-server-nextpvr`** — serves `channel.groups` and honours `group_id`, with a deliberately empty group and one dual-membership channel for manual testing.

## Tests

Group identity and hash stability, both response shapes plus malformed payloads, membership inversion (empty groups, duplicate membership, multi-group), cache apply/re-apply and empty-catalogue fallback, guide filtering combined with search, and preference round-trip with backward-compatible defaults.

Both schemes build on macOS, iOS and tvOS; the 795-test unit suite passes under each.

## Scope note

The Channels-page filter drawer and the search dropdown's group matches remain Dispatcharr-only — the issue's scope covered the sidebar and settings surfaces, so I left those alone rather than widening the change.
