### PR TITLE
Add selectable live TV quality via NextPVR transcoding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ StreamClient is a native Apple streaming client for PVR/DVR servers. Supports iO
 
 ### Variants
 - **StreamClient - For NextPVR** (scheme: `NextPVR`) — targets NextPVR server
-- **StreamClient** (scheme: `DispatcharrPVR`) — targets Dispatcharr server (Django REST API)
+- **StreamClient** (scheme: `Dispatcharr`) — targets Dispatcharr server (Django REST API)
 
 ## Tech Stack
 
@@ -159,21 +159,34 @@ Server config stored separately in `ServerConfig` (Core/Models/Session.swift).
 ## XcodeBuildMCP Integration
 **IMPORTANT**: This project uses XcodeBuildMCP for all Xcode operations.
 ## Build Commands
-- **Build**: Use `mcp__xcodebuildmcp__build_sim_name_proj` for simulator builds
-- **Test**: Use `mcp__xcodebuildmcp__test_sim_name_proj` for running tests
-- **Clean**: Use `mcp__xcodebuildmcp__clean` before major rebuilds
-- **Logs**: Use `mcp__xcodebuildmcp__capture_logs` to debug runtime issues
+
+Call `mcp__XcodeBuildMCP__session_show_defaults` before the first build or
+test of a session — the project/scheme/simulator usually come from session
+defaults, so the build and test tools then take no arguments at all. Use
+`session_set_defaults` with a named profile to check another scheme or
+platform (e.g. the Dispatcharr variant, or tvOS), and switch back with
+`session_use_defaults_profile`.
+
+- **Build**: `mcp__XcodeBuildMCP__build_sim` for simulator builds
+- **Test**: `mcp__XcodeBuildMCP__test_sim`; pass `-only-testing:` via
+  `extraArgs` to run one suite instead of the whole target
+- **Clean**: `mcp__XcodeBuildMCP__clean` before major rebuilds
+- **Logs**: log capture, device, macOS and UI-automation tools are not
+  enabled by default — see https://xcodebuildmcp.com/docs/configuration
 
 ## Build Instructions
 
-The project has two schemes:
+The project has two app schemes:
 - **NextPVR** — StreamClient - For NextPVR
 - **Dispatcharr** — StreamClient
+
+(`NexusPVR TopShelf` and `DispatcherPVR TopShelf` are the tvOS Top Shelf
+extensions, built as part of their app scheme.)
 
 ### Running the App
 
 1. Open `NexusPVR.xcodeproj` in Xcode
-2. Select scheme (NextPVR for StreamClient - For NextPVR, or DispatcharrPVR for StreamClient)
+2. Select scheme (NextPVR for StreamClient - For NextPVR, or Dispatcharr for StreamClient)
 3. Select target (iOS, tvOS, or macOS)
 4. Build and run (Cmd+R)
 
@@ -181,7 +194,9 @@ Note: MPV framework must be properly linked for video playback.
 
 ## Dependencies
 
-- **XcodeGen**: Used to generate .xcodeproj from project.yml (if applicable)
+- **Xcode project**: `NexusPVR.xcodeproj` is checked in and uses synchronized
+  folder groups, so a new Swift file placed in an existing source folder is
+  picked up automatically — no need to edit `project.pbxproj`.
 - **libmpv**: Video playback framework (compiled for each platform)
 - **Swift Package Manager**: Any additional packages via SPM
 

--- a/NexusPVR/AppEntry.swift
+++ b/NexusPVR/AppEntry.swift
@@ -36,6 +36,11 @@ struct PVRApp: App {
             UserPreferences.demoStore = demoPrefs
         }
 
+        // Start watching the network path so the first stream of the session
+        // already knows whether it's on cellular. NWPathMonitor reports the
+        // current path shortly after start, not on demand.
+        NetworkPathMonitor.shared.start()
+
         // Trigger iCloud sync on startup to pull latest data
         NSUbiquitousKeyValueStore.default.synchronize()
 

--- a/NexusPVR/Core/Models/StreamQuality.swift
+++ b/NexusPVR/Core/Models/StreamQuality.swift
@@ -1,0 +1,56 @@
+//
+//  StreamQuality.swift
+//  nextpvr-apple-client
+//
+//  Convenience typealias for the live TV stream quality enum. The canonical
+//  definition lives inside `UserPreferences` so the tvOS Top Shelf extension
+//  (which only shares `UserPreferences.swift` from the Core/Models folder)
+//  keeps compiling without needing this sibling file in its membership list.
+//
+
+typealias StreamQuality = UserPreferences.StreamQuality
+
+extension StreamQuality {
+    /// Whether this option asks the server to transcode. `.original` streams
+    /// the tuner's transport stream directly, which is the only path that
+    /// supports the timeshift buffer and its byte-offset seeking.
+    nonisolated var isTranscoded: Bool { self != .original }
+
+    /// Profile name passed to `channel.transcode.initiate`. NextPVR names its
+    /// stock streaming profiles by resolution — `720p`, `480p` — and Kodi's
+    /// addon builds the same string from its resolution setting.
+    ///
+    /// Nil for `.original`, which never initiates a transcode.
+    nonisolated var profileName: String? {
+        self == .original ? nil : "\(rawValue)p"
+    }
+
+    /// Label shown in Settings.
+    nonisolated var label: String {
+        self == .original ? "Original" : "\(rawValue)p"
+    }
+
+    /// SF Symbol shown next to the option in Settings.
+    nonisolated var icon: String {
+        switch self {
+        case .original: return "tv"
+        case .p1080, .p720: return "rectangle.on.rectangle"
+        default: return "antenna.radiowaves.left.and.right"
+        }
+    }
+
+    /// Explanatory text shown under the picker in Settings.
+    nonisolated var summary: String {
+        switch self {
+        case .original:
+            return "Streams the broadcast untouched at full bitrate. No load on the server, "
+                + "and the only option that supports pausing and seeking live TV."
+        case .p1080, .p720:
+            return "The server re-encodes live TV to \(rawValue)p, cutting bandwidth at the "
+                + "cost of CPU. Needs a server fast enough to transcode in real time."
+        default:
+            return "The server re-encodes live TV to \(rawValue)p — a large bandwidth saving "
+                + "for constrained connections. Pause and seek are unavailable while transcoding."
+        }
+    }
+}

--- a/NexusPVR/Core/Models/TranscodeProgress.swift
+++ b/NexusPVR/Core/Models/TranscodeProgress.swift
@@ -1,0 +1,26 @@
+//
+//  TranscodeProgress.swift
+//  PVR Client
+//
+//  Progress of a server-side live TV transcode, as reported by
+//  NextPVR's `channel.transcode.status` method.
+//
+
+import Foundation
+
+/// Startup progress of a `channel.transcode.initiate` request.
+///
+/// NextPVR counts `percentage` to 100 while it starts ffmpeg and fills the
+/// first HLS segments; the playlist is only playable once it gets there.
+/// `isFinal` means the server has stopped making progress, so a final
+/// document short of 100 is a failed transcode rather than a slow one.
+nonisolated struct TranscodeProgress: Sendable, Equatable {
+    let percentage: Int
+    let isFinal: Bool
+
+    /// The transcode is running and the playlist can be opened.
+    var isReady: Bool { percentage >= 100 }
+
+    /// The server gave up before the stream became playable.
+    var hasFailed: Bool { isFinal && percentage < 100 }
+}

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -27,6 +27,10 @@ nonisolated struct UserPreferences: Codable {
     /// only transcodes when a client asks it to, so an upgrading user sees no
     /// change in bandwidth, quality or CPU load on their server.
     var streamQuality: StreamQuality = .original
+    /// Quality used instead of `streamQuality` while on a metered network
+    /// (cellular, personal hotspot, or Low Data Mode). Nil means "same as
+    /// usual" — the default, so an upgrade changes nothing until asked.
+    var cellularStreamQuality: StreamQuality? = nil
     /// User-selectable tvOS UI font size (#107). Default `.medium`
     /// preserves the pre-feature visual output exactly — existing
     /// users see zero change on first launch after upgrade.
@@ -186,6 +190,7 @@ nonisolated struct UserPreferences: Codable {
         case subtitleBackground
         case deinterlaceMode
         case streamQuality
+        case cellularStreamQuality
         case uiFontSize
         case preferredSubtitleLanguage
         case guideShowGroupsInSidebar
@@ -225,6 +230,7 @@ nonisolated struct UserPreferences: Codable {
         // Prefs written before this setting existed decode to .original, so an
         // upgrade never silently starts transcoding on someone's server.
         streamQuality = try container.decodeIfPresent(StreamQuality.self, forKey: .streamQuality) ?? .original
+        cellularStreamQuality = try container.decodeIfPresent(StreamQuality.self, forKey: .cellularStreamQuality)
         // Forward- and backward-compat: a blob without `uiFontSize`
         // (any prefs written before #107) decodes to .medium so
         // existing users see no visual change.
@@ -254,6 +260,7 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(subtitleBackground, forKey: .subtitleBackground)
         try container.encode(deinterlaceMode, forKey: .deinterlaceMode)
         try container.encode(streamQuality, forKey: .streamQuality)
+        try container.encodeIfPresent(cellularStreamQuality, forKey: .cellularStreamQuality)
         try container.encode(uiFontSize, forKey: .uiFontSize)
         try container.encodeIfPresent(preferredSubtitleLanguage, forKey: .preferredSubtitleLanguage)
         try container.encode(guideShowGroupsInSidebar, forKey: .guideShowGroupsInSidebar)

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -22,6 +22,11 @@ nonisolated struct UserPreferences: Codable {
     /// so interlaced broadcasts (DVB 1080i50 / 576i50, ATSC 1080i60) play
     /// without combing while progressive channels are left untouched.
     var deinterlaceMode: DeinterlaceMode = .auto
+    /// Server-side transcoding profile requested for live TV. Defaults to
+    /// `.original`, which keeps the existing direct-stream behaviour: NextPVR
+    /// only transcodes when a client asks it to, so an upgrading user sees no
+    /// change in bandwidth, quality or CPU load on their server.
+    var streamQuality: StreamQuality = .original
     /// User-selectable tvOS UI font size (#107). Default `.medium`
     /// preserves the pre-feature visual output exactly — existing
     /// users see zero change on first launch after upgrade.
@@ -66,6 +71,32 @@ nonisolated struct UserPreferences: Codable {
     var theme: AppTheme {
         get { AppTheme(rawValue: themeRawValue) ?? .system }
         set { themeRawValue = newValue.rawValue }
+    }
+
+    /// Live TV stream quality. `.original` streams the tuner's transport
+    /// stream untouched (what the app has always done); every other case asks
+    /// NextPVR to transcode via `channel.transcode.initiate`, trading server
+    /// CPU for bandwidth.
+    ///
+    /// The raw values are the resolutions Kodi's `pvr.nextpvr` addon offers,
+    /// in the same order, because those are the profile names NextPVR servers
+    /// ship with — see `instance-settings.xml` in that addon.
+    ///
+    /// Nested here for the same reason as `DeinterlaceMode` — the tvOS Top
+    /// Shelf extension shares `UserPreferences.swift` but not its sibling
+    /// Core/Models files.
+    nonisolated enum StreamQuality: String, CaseIterable, Identifiable, Codable {
+        case original = "Original"
+        case p1080 = "1080"
+        case p720 = "720"
+        case p576 = "576"
+        case p504 = "504"
+        case p480 = "480"
+        case p360 = "360"
+        case p240 = "240"
+        case p144 = "144"
+
+        var id: String { rawValue }
     }
 
     /// User-selectable deinterlacing mode (#142). Nested here for the same
@@ -154,6 +185,7 @@ nonisolated struct UserPreferences: Codable {
         case subtitleSize
         case subtitleBackground
         case deinterlaceMode
+        case streamQuality
         case uiFontSize
         case preferredSubtitleLanguage
         case guideShowGroupsInSidebar
@@ -190,6 +222,9 @@ nonisolated struct UserPreferences: Codable {
         // Prefs written before #142 have no `deinterlaceMode`; they decode to
         // .auto, which is the recommended default for broadcast streams.
         deinterlaceMode = try container.decodeIfPresent(DeinterlaceMode.self, forKey: .deinterlaceMode) ?? .auto
+        // Prefs written before this setting existed decode to .original, so an
+        // upgrade never silently starts transcoding on someone's server.
+        streamQuality = try container.decodeIfPresent(StreamQuality.self, forKey: .streamQuality) ?? .original
         // Forward- and backward-compat: a blob without `uiFontSize`
         // (any prefs written before #107) decodes to .medium so
         // existing users see no visual change.
@@ -218,6 +253,7 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(subtitleSize, forKey: .subtitleSize)
         try container.encode(subtitleBackground, forKey: .subtitleBackground)
         try container.encode(deinterlaceMode, forKey: .deinterlaceMode)
+        try container.encode(streamQuality, forKey: .streamQuality)
         try container.encode(uiFontSize, forKey: .uiFontSize)
         try container.encodeIfPresent(preferredSubtitleLanguage, forKey: .preferredSubtitleLanguage)
         try container.encode(guideShowGroupsInSidebar, forKey: .guideShowGroupsInSidebar)

--- a/NexusPVR/Core/Services/Dependencies.swift
+++ b/NexusPVR/Core/Services/Dependencies.swift
@@ -27,6 +27,11 @@ enum Dependencies {
         defaultImageCache
     }
 
+    /// App-wide default network path reporter (protocol for testability)
+    static var networkPathReporter: any NetworkPathReporting {
+        NetworkPathMonitor.shared
+    }
+
     /// App-wide default network event logger (protocol for testability)
     static var networkEventLogger: any NetworkEventLogging {
         defaultNetworkEventLog

--- a/NexusPVR/Core/Services/NetworkPathMonitor.swift
+++ b/NexusPVR/Core/Services/NetworkPathMonitor.swift
@@ -1,0 +1,60 @@
+//
+//  NetworkPathMonitor.swift
+//  PVR Client
+//
+//  Reports whether the current network is one the user would rather not stream
+//  full-bitrate video over.
+//
+
+import Foundation
+import Network
+
+/// Protocol so callers can be tested without a real network path.
+nonisolated protocol NetworkPathReporting: AnyObject, Sendable {
+    /// True when the active path is metered or the user has asked for less data:
+    /// cellular, a personal hotspot, or Low Data Mode.
+    var prefersReducedData: Bool { get }
+}
+
+/// Watches the default network path.
+///
+/// Deliberately keyed on `isExpensive` / `isConstrained` rather than on the
+/// interface type: `isExpensive` covers a personal hotspot as well as cellular,
+/// and `isConstrained` is the user having switched on Low Data Mode, which is a
+/// direct request to use less data and worth honouring for the same reason.
+///
+/// Reads happen while a stream is being opened, so the value is kept in a plain
+/// lock-guarded field rather than behind an actor — the caller must not have to
+/// await it.
+nonisolated final class NetworkPathMonitor: NetworkPathReporting, @unchecked Sendable {
+    static let shared = NetworkPathMonitor()
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "NetworkPathMonitor")
+    private let lock = NSLock()
+    private var _prefersReducedData = false
+    private var started = false
+
+    var prefersReducedData: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _prefersReducedData
+    }
+
+    /// Begins watching. Safe to call more than once.
+    func start() {
+        lock.lock()
+        guard !started else { return lock.unlock() }
+        started = true
+        lock.unlock()
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let reduced = path.isExpensive || path.isConstrained
+            self.lock.lock()
+            self._prefersReducedData = reduced
+            self.lock.unlock()
+        }
+        monitor.start(queue: queue)
+    }
+}

--- a/NexusPVR/Core/Services/NextPVRClient.swift
+++ b/NexusPVR/Core/Services/NextPVRClient.swift
@@ -13,6 +13,10 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     @Published private(set) var isAuthenticated = false
     @Published private(set) var isConnecting = false
     @Published private(set) var lastError: NextPVRError?
+    /// Set when a requested transcode couldn't be started and playback fell back
+    /// to the original stream, so the player can say so once rather than leaving
+    /// the user to wonder why their quality setting did nothing.
+    @Published private(set) var streamQualityNotice: String?
 
     private(set) var config: ServerConfig
     private var sid: String?
@@ -723,6 +727,7 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     /// demuxer cache. Kodi makes the same split in `OpenLiveStream`; `client` being the
     /// SID rather than a device name is what its timeshift path sends.
     func liveStreamURL(channelId: Int) async throws -> URL {
+        streamQualityNotice = nil
         guard !config.isDemoMode else { return DemoDataProvider.demoVideoURL }
 
         // Release any previous stream before rotating the SID, otherwise the old
@@ -736,9 +741,15 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         // one: HLS off `channel.transcode.m3u8` rather than a raw transport
         // stream off `/live`. Falls through to the direct path when the server
         // can't transcode, so a misconfigured or overloaded server still plays.
-        if let profile = requestedStreamQuality.profileName,
-           let url = await startTranscodedStream(channelId: channelId, profile: profile, sid: sid) {
-            return url
+        if let profile = requestedStreamQuality.profileName {
+            if let url = await startTranscodedStream(channelId: channelId, profile: profile, sid: sid) {
+                return url
+            }
+            // Every reason for landing here is logged in detail by
+            // `startTranscodedStream`; this is the one-line version the player
+            // shows, so a dropped quality setting is never silent.
+            streamQualityNotice = "The server couldn't transcode to \(profile) — "
+                + "playing at original quality."
         }
 
         // Degrade to the realtime shape if the server won't start a timeshift
@@ -1094,6 +1105,10 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
             streamLength: length,
             isComplete: parser.isComplete ?? false
         )
+    }
+
+    func clearStreamQualityNotice() {
+        streamQualityNotice = nil
     }
 
     func streamAuthHeaders() -> [String: String] {

--- a/NexusPVR/Core/Services/NextPVRClient.swift
+++ b/NexusPVR/Core/Services/NextPVRClient.swift
@@ -28,6 +28,7 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     private let deviceName = Brand.deviceName
     private var authInProgress: Task<Void, Error>?
     private let networkEventLogger: any NetworkEventLogging
+    private let networkPath: any NetworkPathReporting
     /// Channel of the live timeshift stream currently registered with the server,
     /// so it can be released on teardown or channel change.
     private var activeLiveChannelId: Int?
@@ -47,8 +48,22 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     /// shared preferences store.
     var streamQualityOverride: StreamQuality?
 
-    private var requestedStreamQuality: StreamQuality {
-        streamQualityOverride ?? UserPreferences.load().streamQuality
+    /// Picks the quality to request for this stream.
+    ///
+    /// The cellular choice is honoured literally rather than only when it is
+    /// lower: it is an explicit per-network setting, and second-guessing it
+    /// would make the picker mean different things on different networks.
+    ///
+    /// Evaluated once, when the stream opens. Moving between Wi-Fi and cellular
+    /// mid-programme doesn't re-negotiate — that would mean tearing down and
+    /// restarting playback under the user.
+    nonisolated static func effectiveStreamQuality(
+        usual: StreamQuality,
+        cellular: StreamQuality?,
+        onMeteredNetwork: Bool
+    ) -> StreamQuality {
+        guard onMeteredNetwork, let cellular else { return usual }
+        return cellular
     }
 
     /// How long to wait for the server-side buffer to fill before opening the
@@ -63,9 +78,12 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     /// Cadence of the `channel.transcode.status` poll, matching Kodi's.
     private static let transcodeStatusInterval: Duration = .seconds(1)
 
-    init(config: ServerConfig? = nil, networkEventLogger: some NetworkEventLogging = Dependencies.networkEventLog) {
+    init(config: ServerConfig? = nil,
+         networkEventLogger: some NetworkEventLogging = Dependencies.networkEventLog,
+         networkPath: any NetworkPathReporting = Dependencies.networkPathReporter) {
         self.config = config ?? ServerConfig.load()
         self.networkEventLogger = networkEventLogger
+        self.networkPath = networkPath
         let configuration = URLSessionConfiguration.default
         configuration.waitsForConnectivity = true
         configuration.timeoutIntervalForRequest = 30
@@ -741,7 +759,19 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         // one: HLS off `channel.transcode.m3u8` rather than a raw transport
         // stream off `/live`. Falls through to the direct path when the server
         // can't transcode, so a misconfigured or overloaded server still plays.
-        if let profile = requestedStreamQuality.profileName {
+        let prefs = UserPreferences.load()
+        let quality = streamQualityOverride ?? Self.effectiveStreamQuality(
+            usual: prefs.streamQuality,
+            cellular: prefs.cellularStreamQuality,
+            onMeteredNetwork: networkPath.prefersReducedData
+        )
+        // Say so when the metered-network rule changed the quality, so a picture
+        // that looks worse than usual has a visible reason.
+        if streamQualityOverride == nil, quality != prefs.streamQuality {
+            streamQualityNotice = "On a metered network — playing at \(quality.label)."
+        }
+
+        if let profile = quality.profileName {
             if let url = await startTranscodedStream(channelId: channelId, profile: profile, sid: sid) {
                 return url
             }

--- a/NexusPVR/Core/Services/NextPVRClient.swift
+++ b/NexusPVR/Core/Services/NextPVRClient.swift
@@ -33,12 +33,31 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     private var lastStreamInfoAt: Date = .distantPast
     /// Base `/live` URL of the active timeshift stream, used to build seek URLs.
     private var activeLiveStreamURL: URL?
+    /// Channel of the server-side transcode currently running for this session,
+    /// so it can be stopped on teardown or channel change. Mutually exclusive
+    /// with `activeLiveChannelId`: a stream is either direct or transcoded.
+    private var activeTranscodeChannelId: Int?
+
+    /// Live TV stream quality, read from user preferences when a stream starts.
+    /// Overridable so tests can drive the transcode path without writing to the
+    /// shared preferences store.
+    var streamQualityOverride: StreamQuality?
+
+    private var requestedStreamQuality: StreamQuality {
+        streamQualityOverride ?? UserPreferences.load().streamQuality
+    }
 
     /// How long to wait for the server-side buffer to fill before opening the
     /// stream anyway.
     private static let liveStreamReadyTimeout: TimeInterval = 5
     /// Buffer-state polling cadence, matching Kodi's `LeaseWorker`.
     private static let streamInfoInterval: TimeInterval = 10
+    /// How long to wait for the server to spin up a transcode before giving up
+    /// and falling back to the direct stream. Starting ffmpeg and filling the
+    /// first HLS segments is slower than opening a tuner, so this is generous.
+    private static let transcodeReadyTimeout: TimeInterval = 30
+    /// Cadence of the `channel.transcode.status` poll, matching Kodi's.
+    private static let transcodeStatusInterval: Duration = .seconds(1)
 
     init(config: ServerConfig? = nil, networkEventLogger: some NetworkEventLogging = Dependencies.networkEventLog) {
         self.config = config ?? ServerConfig.load()
@@ -713,6 +732,15 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         try await refreshSessionForStreaming()
         guard let sid else { throw NextPVRError.sessionExpired }
 
+        // A transcoded stream is a different protocol, not a parameter on this
+        // one: HLS off `channel.transcode.m3u8` rather than a raw transport
+        // stream off `/live`. Falls through to the direct path when the server
+        // can't transcode, so a misconfigured or overloaded server still plays.
+        if let profile = requestedStreamQuality.profileName,
+           let url = await startTranscodedStream(channelId: channelId, profile: profile, sid: sid) {
+            return url
+        }
+
         // Degrade to the realtime shape if the server won't start a timeshift
         // stream (older NextPVR, no free tuner). Playback still works; it just
         // can't survive a long pause, which is the pre-existing behaviour.
@@ -779,23 +807,30 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         return true
     }
 
-    /// True while a timeshift handle is open on the server. Guards the foreground
-    /// re-authentication, which would otherwise rotate the SID that owns it.
-    var hasActiveLiveStream: Bool { activeLiveChannelId != nil }
+    /// True while a timeshift handle or a transcode is open on the server. Guards
+    /// the foreground re-authentication, which would otherwise rotate the SID that
+    /// owns it — the transcode playlist URL carries the SID too, so re-auth would
+    /// break a transcoded stream just as surely as a direct one.
+    var hasActiveLiveStream: Bool { activeLiveChannelId != nil || activeTranscodeChannelId != nil }
 
     /// Releases the server-side timeshift buffer so the tuner is freed immediately
     /// rather than after the 15s renewal timeout. Best-effort: teardown must not
     /// throw or block.
     func stopLiveStream() async {
-        guard !config.isDemoMode, activeLiveChannelId != nil else { return }
+        guard !config.isDemoMode else { return }
+        if activeTranscodeChannelId != nil {
+            await stopTranscodedStream()
+        }
+        guard activeLiveChannelId != nil else { return }
         activeLiveChannelId = nil
         activeLiveStreamURL = nil
-        try? await streamAction("channel.stream.stop")
+        _ = try? await streamAction("channel.stream.stop")
     }
 
     /// Issues one of the `channel.stream.*` methods. These live under `/service`
     /// (not `/services/service` like every other method here) and answer raw XML.
-    private func streamAction(_ method: String, params: [String: String] = [:]) async throws {
+    @discardableResult
+    private func streamAction(_ method: String, params: [String: String] = [:]) async throws -> Data {
         guard let sid else { throw NextPVRError.sessionExpired }
 
         var components = URLComponents(string: "\(baseURL)/service")!
@@ -811,10 +846,99 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
             throw NextPVRError.invalidResponse
         }
 
-        let (_, response) = try await loggedData(from: url)
+        let (data, response) = try await loggedData(from: url)
         if let status = (response as? HTTPURLResponse)?.statusCode, !(200...299).contains(status) {
             throw NextPVRError.apiError("\(method) failed with HTTP \(status)")
         }
+        return data
+    }
+
+    // MARK: - Transcoded streaming
+
+    /// Asks the server to transcode a channel and returns the HLS playlist URL
+    /// once it is playable, or nil if it never becomes playable.
+    ///
+    /// NextPVR only transcodes when a client asks: `channel.transcode.initiate`
+    /// starts ffmpeg with a named server-side profile (`720p`, `480p`, …),
+    /// `channel.transcode.status` counts to 100 while it fills the first
+    /// segments, and the stream is then served as HLS from
+    /// `channel.transcode.m3u8`. This is Kodi's `Transcoded` streaming method.
+    ///
+    /// Returning nil is not an error — the caller falls back to the direct
+    /// stream, which is worse for bandwidth but always works.
+    private func startTranscodedStream(channelId: Int, profile: String, sid: String) async -> URL? {
+        do {
+            let response = try await streamAction("channel.transcode.initiate", params: [
+                "force": "true",
+                "channel_id": String(channelId),
+                "profile": profile
+            ])
+            // NextPVR answers 200 with `<rsp stat="fail">` for an unknown
+            // profile, so the HTTP status alone doesn't say the transcode started.
+            if let body = String(data: response, encoding: .utf8), body.contains("stat=\"fail\"") {
+                print("[NextPVR] channel.transcode.initiate rejected profile \(profile); "
+                    + "falling back to the direct stream. Check the server's streaming profiles.")
+                return nil
+            }
+        } catch {
+            print("[NextPVR] channel.transcode.initiate failed, falling back to the direct "
+                + "stream: \(error.localizedDescription)")
+            return nil
+        }
+
+        // Claim the session now: the transcode has to be stopped even if it
+        // never becomes playable, or it holds the tuner until the server times out.
+        activeTranscodeChannelId = channelId
+
+        let deadline = Date().addingTimeInterval(Self.transcodeReadyTimeout)
+        while Date() < deadline {
+            if let progress = try? await fetchTranscodeStatus() {
+                if progress.isReady {
+                    var components = URLComponents(string: "\(baseURL)/service")
+                    components?.queryItems = [
+                        URLQueryItem(name: "method", value: "channel.transcode.m3u8"),
+                        URLQueryItem(name: "sid", value: sid)
+                    ]
+                    if let url = components?.url {
+                        return url
+                    }
+                    break
+                }
+                if progress.hasFailed {
+                    print("[NextPVR] transcode stalled at \(progress.percentage)%, falling back "
+                        + "to the direct stream. The server may be too slow for \(profile).")
+                    break
+                }
+            }
+            try? await Task.sleep(for: Self.transcodeStatusInterval)
+        }
+
+        await stopTranscodedStream()
+        return nil
+    }
+
+    /// Releases the server-side transcode so ffmpeg exits and the tuner is freed
+    /// immediately. Best-effort: teardown must not throw or block.
+    private func stopTranscodedStream() async {
+        guard activeTranscodeChannelId != nil else { return }
+        activeTranscodeChannelId = nil
+        _ = try? await streamAction("channel.transcode.stop")
+    }
+
+    /// Polls the startup progress of the running transcode.
+    private func fetchTranscodeStatus() async throws -> TranscodeProgress? {
+        Self.parseTranscodeStatus(try await streamAction("channel.transcode.status"))
+    }
+
+    /// Parses the document returned by `channel.transcode.status`. Like the other
+    /// `/service` stream methods it answers raw XML, so it can't go through
+    /// `request(_:params:)`.
+    nonisolated static func parseTranscodeStatus(_ data: Data) -> TranscodeProgress? {
+        let parser = TranscodeStatusXMLParser()
+        guard parser.parse(data), let percentage = parser.percentage else {
+            return nil
+        }
+        return TranscodeProgress(percentage: percentage, isFinal: parser.isFinal ?? false)
     }
 
     func recordingStreamURL(recordingId: Int) async throws -> URL {
@@ -842,6 +966,11 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
     @discardableResult
     func renewLiveStream() async throws -> LiveStreamInfo? {
         guard !config.isDemoMode else { return nil }
+        // A transcoded stream renews itself: the player's playlist and segment
+        // requests are what keep it alive, and there is no timeshift buffer to
+        // report on. Kodi's `TranscodedBuffer` skips both calls for the same
+        // reason — sending them here would just 404 every tick.
+        guard activeTranscodeChannelId == nil else { return nil }
         // Nothing to renew when the stream fell back to realtime — the server would
         // just 404, once every keepalive tick.
         guard activeLiveChannelId != nil || isStartingLiveStream else { return nil }

--- a/NexusPVR/Core/Services/NextPVRClient.swift
+++ b/NexusPVR/Core/Services/NextPVRClient.swift
@@ -873,16 +873,21 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
                 "channel_id": String(channelId),
                 "profile": profile
             ])
-            // NextPVR answers 200 with `<rsp stat="fail">` for an unknown
-            // profile, so the HTTP status alone doesn't say the transcode started.
-            if let body = String(data: response, encoding: .utf8), body.contains("stat=\"fail\"") {
-                print("[NextPVR] channel.transcode.initiate rejected profile \(profile); "
-                    + "falling back to the direct stream. Check the server's streaming profiles.")
+            // NextPVR rejects an undefined profile with `<rsp stat="fail">` at
+            // HTTP 200, so the status code alone doesn't say the transcode
+            // started, and `loggedData` records no body for a 200. Log the
+            // answer either way — a silent fallback is indistinguishable from
+            // the feature not working at all.
+            if let failure = Self.transcodeFailure(response) {
+                logTranscode("initiate refused profile '\(profile)': \(failure). "
+                    + "Falling back to the direct stream.", isSuccess: false)
                 return nil
             }
+            logTranscode("initiate accepted profile '\(profile)' for channel \(channelId)",
+                         isSuccess: true)
         } catch {
-            print("[NextPVR] channel.transcode.initiate failed, falling back to the direct "
-                + "stream: \(error.localizedDescription)")
+            logTranscode("initiate failed: \(error.localizedDescription). "
+                + "Falling back to the direct stream.", isSuccess: false)
             return nil
         }
 
@@ -890,9 +895,30 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         // never becomes playable, or it holds the tuner until the server times out.
         activeTranscodeChannelId = channelId
 
+        var lastPercentage = -1
         let deadline = Date().addingTimeInterval(Self.transcodeReadyTimeout)
         while Date() < deadline {
-            if let progress = try? await fetchTranscodeStatus() {
+            do {
+                let data = try await streamAction("channel.transcode.status")
+                // A transcode whose ffmpeg died reports `stat="fail"` here too,
+                // with no <percentage> — stop rather than waiting out the timeout.
+                if let failure = Self.transcodeFailure(data) {
+                    logTranscode("transcode failed after starting: \(failure). "
+                        + "Falling back to the direct stream.", isSuccess: false)
+                    break
+                }
+                guard let progress = Self.parseTranscodeStatus(data) else {
+                    logTranscode("status was unparseable: "
+                        + "\((String(data: Data(data.prefix(256)), encoding: .utf8) ?? "<unreadable>").trimmingCharacters(in: .whitespacesAndNewlines))",
+                        isSuccess: false)
+                    try? await Task.sleep(for: Self.transcodeStatusInterval)
+                    continue
+                }
+                if progress.percentage != lastPercentage {
+                    lastPercentage = progress.percentage
+                    logTranscode("status \(progress.percentage)%\(progress.isFinal ? " (final)" : "")",
+                                 isSuccess: true)
+                }
                 if progress.isReady {
                     var components = URLComponents(string: "\(baseURL)/service")
                     components?.queryItems = [
@@ -900,21 +926,48 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
                         URLQueryItem(name: "sid", value: sid)
                     ]
                     if let url = components?.url {
+                        logTranscode("ready — playing \(profile) HLS stream", isSuccess: true)
                         return url
                     }
                     break
                 }
                 if progress.hasFailed {
-                    print("[NextPVR] transcode stalled at \(progress.percentage)%, falling back "
-                        + "to the direct stream. The server may be too slow for \(profile).")
+                    logTranscode("stalled at \(progress.percentage)% — the server stopped making "
+                        + "progress. It may be unable to transcode \(profile) in real time, or the "
+                        + "transcoder is not configured. Falling back to the direct stream.",
+                        isSuccess: false)
                     break
                 }
+            } catch {
+                logTranscode("status request failed: \(error.localizedDescription)", isSuccess: false)
             }
             try? await Task.sleep(for: Self.transcodeStatusInterval)
         }
 
+        if lastPercentage < 100 {
+            logTranscode("gave up after \(Int(Self.transcodeReadyTimeout))s at \(lastPercentage)%. "
+                + "Falling back to the direct stream.", isSuccess: false)
+        }
         await stopTranscodedStream()
         return nil
+    }
+
+    /// Records a step of the transcode negotiation in the in-app event log
+    /// (Settings > Event Log) as well as the console. These steps decide whether
+    /// the user's chosen quality is honoured or silently dropped, so they have to
+    /// be visible without a debugger attached.
+    private func logTranscode(_ message: String, isSuccess: Bool) {
+        print("[NextPVR] transcode: \(message)")
+        networkEventLogger.log(NetworkEvent(
+            timestamp: Date(),
+            method: "TRANSCODE",
+            path: "/service?method=channel.transcode.*",
+            statusCode: nil,
+            isSuccess: isSuccess,
+            durationMs: 0,
+            responseSize: 0,
+            errorDetail: message
+        ))
     }
 
     /// Releases the server-side transcode so ffmpeg exits and the tuner is freed
@@ -925,14 +978,24 @@ final class NextPVRClient: ObservableObject, PVRClientProtocol {
         _ = try? await streamAction("channel.transcode.stop")
     }
 
-    /// Polls the startup progress of the running transcode.
-    private func fetchTranscodeStatus() async throws -> TranscodeProgress? {
-        Self.parseTranscodeStatus(try await streamAction("channel.transcode.status"))
-    }
-
     /// Parses the document returned by `channel.transcode.status`. Like the other
     /// `/service` stream methods it answers raw XML, so it can't go through
     /// `request(_:params:)`.
+    /// Reads a refusal out of any `channel.transcode.*` response, returning the
+    /// server's own wording, or nil when the response is not a refusal.
+    ///
+    /// NextPVR reports these at HTTP 200: it accepts the request, spawns ffmpeg,
+    /// and only then discovers the encode cannot run — a missing streaming
+    /// profile, or a hardware encoder it can't open. Reading the body is the
+    /// only way to tell a started transcode from a dead one.
+    nonisolated static func transcodeFailure(_ data: Data) -> String? {
+        let parser = TranscodeStatusXMLParser()
+        guard parser.parse(data), parser.stat == "fail" else { return nil }
+        let message = parser.errorMessage ?? "no message"
+        guard let code = parser.errorCode else { return message }
+        return "\(message) (err \(code))"
+    }
+
     nonisolated static func parseTranscodeStatus(_ data: Data) -> TranscodeProgress? {
         let parser = TranscodeStatusXMLParser()
         guard parser.parse(data), let percentage = parser.percentage else {

--- a/NexusPVR/Core/Services/PVRClientProtocol.swift
+++ b/NexusPVR/Core/Services/PVRClientProtocol.swift
@@ -46,6 +46,12 @@ protocol PVRClientProtocol: ObservableObject {
     /// URL replaying the live buffer from `byteOffset`, or nil when the backend
     /// has no seekable server-side buffer.
     func liveStreamSeekURL(byteOffset: Int64) -> URL?
+    /// Set when the last `liveStreamURL(channelId:)` could not honour the user's
+    /// chosen stream quality and fell back to the original stream. The player
+    /// shows this once so the fallback isn't silent; nil when nothing to report.
+    var streamQualityNotice: String? { get }
+    /// Clears the notice once the player has shown it.
+    func clearStreamQualityNotice()
     func recordingStreamURL(recordingId: Int) async throws -> URL
     func streamAuthHeaders() -> [String: String]
     func channelIconURL(channelId: Int) throws -> URL?
@@ -69,4 +75,8 @@ extension PVRClientProtocol {
     var hasActiveLiveStream: Bool { false }
 
     func liveStreamSeekURL(byteOffset: Int64) -> URL? { nil }
+
+    var streamQualityNotice: String? { nil }
+
+    func clearStreamQualityNotice() {}
 }

--- a/NexusPVR/Core/Services/TranscodeStatusXMLParser.swift
+++ b/NexusPVR/Core/Services/TranscodeStatusXMLParser.swift
@@ -1,0 +1,66 @@
+//
+//  TranscodeStatusXMLParser.swift
+//  PVR Client
+//
+//  Parses the raw XML document returned by NextPVR's
+//  `channel.transcode.status` method.
+//
+
+import Foundation
+
+/// Extracts progress from a `channel.transcode.status` response:
+///
+/// ```xml
+/// <rsp stat="ok">
+///   <percentage>100</percentage>
+///   <final>false</final>
+/// </rsp>
+/// ```
+///
+/// `percentage` counts up to 100 as the server spins up ffmpeg and fills the
+/// first HLS segments; the stream is only playable at 100. `final` means the
+/// server has stopped making progress, so a `final` document short of 100 is
+/// a failed transcode, not a slow one — the same reading Kodi's
+/// `TranscodedBuffer::TranscodeStatus` applies.
+nonisolated final class TranscodeStatusXMLParser: NSObject, XMLParserDelegate {
+    private(set) var percentage: Int?
+    private(set) var isFinal: Bool?
+
+    private var currentText = ""
+
+    /// Returns false when the document is not well-formed. Fields that are
+    /// absent stay nil.
+    func parse(_ data: Data) -> Bool {
+        let parser = XMLParser(data: data)
+        parser.delegate = self
+        return parser.parse()
+    }
+
+    func parser(_ parser: XMLParser,
+                didStartElement elementName: String,
+                namespaceURI: String?,
+                qualifiedName qName: String?,
+                attributes attributeDict: [String: String]) {
+        currentText = ""
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        currentText += string
+    }
+
+    func parser(_ parser: XMLParser,
+                didEndElement elementName: String,
+                namespaceURI: String?,
+                qualifiedName qName: String?) {
+        let value = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch elementName {
+        case "percentage":
+            percentage = Int(value)
+        case "final":
+            isFinal = (value as NSString).boolValue
+        default:
+            break
+        }
+        currentText = ""
+    }
+}

--- a/NexusPVR/Core/Services/TranscodeStatusXMLParser.swift
+++ b/NexusPVR/Core/Services/TranscodeStatusXMLParser.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-/// Extracts progress from a `channel.transcode.status` response:
+/// Extracts progress from a `channel.transcode.status` response, and the
+/// `stat`/`<err>` fields common to every `channel.transcode.*` answer:
 ///
 /// ```xml
 /// <rsp stat="ok">
@@ -22,9 +23,18 @@ import Foundation
 /// server has stopped making progress, so a `final` document short of 100 is
 /// a failed transcode, not a slow one — the same reading Kodi's
 /// `TranscodedBuffer::TranscodeStatus` applies.
+/// A refusal arrives as `<rsp stat="fail"><err code="11" msg="..."/></rsp>` at
+/// HTTP 200 — NextPVR accepts the request, spawns ffmpeg, and reports the
+/// failure only once ffmpeg exits — so the status code alone never says whether
+/// a transcode started.
 nonisolated final class TranscodeStatusXMLParser: NSObject, XMLParserDelegate {
     private(set) var percentage: Int?
     private(set) var isFinal: Bool?
+    /// The `stat` attribute of the root `<rsp>` element, when present.
+    private(set) var stat: String?
+    /// The `msg` attribute of an `<err>` element, when the server refused.
+    private(set) var errorMessage: String?
+    private(set) var errorCode: String?
 
     private var currentText = ""
 
@@ -41,6 +51,15 @@ nonisolated final class TranscodeStatusXMLParser: NSObject, XMLParserDelegate {
                 namespaceURI: String?,
                 qualifiedName qName: String?,
                 attributes attributeDict: [String: String]) {
+        switch elementName {
+        case "rsp":
+            stat = attributeDict["stat"]
+        case "err":
+            errorMessage = attributeDict["msg"]
+            errorCode = attributeDict["code"]
+        default:
+            break
+        }
         currentText = ""
     }
 

--- a/NexusPVR/Features/Player/PlayerView.swift
+++ b/NexusPVR/Features/Player/PlayerView.swift
@@ -54,6 +54,11 @@ struct PlayerView: View {
     @State private var hideControlsTask: Task<Void, Never>?
     @State private var isPlaying = true
     @State private var errorMessage: String?
+    /// Copy of the client's stream-quality fallback notice, held locally so it
+    /// can be dismissed and auto-hidden without clearing the client's state
+    /// before the banner has been seen.
+    @State private var qualityNotice: String?
+    @State private var qualityNoticeTask: Task<Void, Never>?
     @State private var currentPosition: Double = 0
     @State private var duration: Double = 0
     @State private var isSeeking = false
@@ -538,6 +543,31 @@ struct PlayerView: View {
                 }
             }
 
+            // Stream-quality fallback notice. Informational, not an error: the
+            // stream is playing, just not at the requested quality, so it sits
+            // apart from the red error overlay and clears itself.
+            if let notice = qualityNotice {
+                VStack {
+                    HStack(spacing: Theme.spacingSM) {
+                        Image(systemName: "exclamationmark.circle")
+                        Text(notice)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .font(.footnote)
+                    .foregroundStyle(.white)
+                    .padding(Theme.spacingSM)
+                    .background(Color.black.opacity(0.75))
+                    .cornerRadius(Theme.cornerRadiusSM)
+                    .padding(Theme.spacingMD)
+                    #if !os(tvOS)
+                    .onTapGesture { dismissQualityNotice() }
+                    #endif
+                    Spacer()
+                }
+                .transition(.opacity)
+                .allowsHitTesting(true)
+            }
+
             #if os(macOS)
             // Hidden buttons for keyboard shortcuts
             // Hidden buttons for keyboard shortcuts — must have non-zero frame to receive events
@@ -584,6 +614,7 @@ struct PlayerView: View {
         }
         #endif
         .onAppear {
+            adoptQualityNotice()
             scheduleHideControls()
             #if os(macOS)
             updatePowerAssertion()
@@ -597,6 +628,7 @@ struct PlayerView: View {
             #endif
         }
         .onDisappear {
+            qualityNoticeTask?.cancel()
             #if os(tvOS)
             clearDisplayCriteria()
             #endif
@@ -702,6 +734,9 @@ struct PlayerView: View {
             // PlayerPowerAssertion.
             updatePowerAssertion()
             #endif
+        }
+        .onChange(of: client.streamQualityNotice) { _ in
+            adoptQualityNotice()
         }
         .task(id: isPlayerReady) {
             guard isPlayerReady else { return }
@@ -914,6 +949,32 @@ struct PlayerView: View {
     /// playback, freeing the server-side slot immediately instead of
     /// waiting out the 10-minute idle TTL. Reads the view's own
     /// `catchupSessionId` rather than `appState`'s, since `appState.stopPlayback()`
+    /// Takes the client's fallback notice, shows it, and clears it from the
+    /// client so a later channel change reports its own outcome. Auto-hides:
+    /// the stream is playing fine, so the banner shouldn't sit over the video.
+    private func adoptQualityNotice() {
+        guard let notice = client.streamQualityNotice else { return }
+        client.clearStreamQualityNotice()
+        withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+            qualityNotice = notice
+        }
+        qualityNoticeTask?.cancel()
+        qualityNoticeTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(8))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+                qualityNotice = nil
+            }
+        }
+    }
+
+    private func dismissQualityNotice() {
+        qualityNoticeTask?.cancel()
+        withAnimation(.easeInOut(duration: Theme.animationDuration)) {
+            qualityNotice = nil
+        }
+    }
+
     /// (called just before this in `.onDisappear`) already clears the
     /// published copy.
     private func endCatchupSessionIfNeeded() {

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -25,6 +25,9 @@ struct SettingsView: View {
     @State private var subtitleSize: SubtitleSize = UserPreferences.load().subtitleSize
     @State private var subtitleBackground: Bool = UserPreferences.load().subtitleBackground
     @State private var deinterlaceMode: DeinterlaceMode = UserPreferences.load().deinterlaceMode
+    #if !DISPATCHERPVR
+    @State private var streamQuality: StreamQuality = UserPreferences.load().streamQuality
+    #endif
     @State private var landingTab: LandingTabOption = UserPreferences.load().landingTab
     @State private var hideRecordings: Bool = UserPreferences.load().hideRecordings
     @State private var theme: AppTheme = UserPreferences.load().theme
@@ -63,6 +66,9 @@ struct SettingsView: View {
         case subtitleSize
         case subtitleBackground
         case deinterlace
+        #if !DISPATCHERPVR
+        case streamQuality
+        #endif
         case renderer
         case landingTab
         case hideRecordings
@@ -222,6 +228,16 @@ struct SettingsView: View {
                             ) {
                                 activeTVPopup = .audioOutput
                             }
+                            #if !DISPATCHERPVR
+                            tvSettingsRow(
+                                title: "Live TV Quality",
+                                value: streamQuality.label,
+                                icon: streamQuality.icon,
+                                detail: streamQualityDescription
+                            ) {
+                                activeTVPopup = .streamQuality
+                            }
+                            #endif
                             tvSettingsRow(
                                 title: "Deinterlacing",
                                 value: deinterlaceMode.label,
@@ -779,6 +795,10 @@ struct SettingsView: View {
             return "Audio Output"
         case .deinterlace:
             return "Deinterlacing"
+        #if !DISPATCHERPVR
+        case .streamQuality:
+            return "Live TV Quality"
+        #endif
         case .subtitleMode:
             return "Subtitles"
         case .subtitleSize:
@@ -871,6 +891,22 @@ struct SettingsView: View {
                     prefs.save()
                 }
             }
+        #if !DISPATCHERPVR
+        case .streamQuality:
+            return StreamQuality.allCases.map { quality in
+                TVPopupOption(
+                    id: "settings-popup-stream-quality-\(quality.rawValue)",
+                    title: quality.label,
+                    isCurrent: streamQuality == quality,
+                    isDestructive: false
+                ) {
+                    streamQuality = quality
+                    var prefs = UserPreferences.load()
+                    prefs.streamQuality = quality
+                    prefs.save()
+                }
+            }
+        #endif
         case .subtitleMode:
             return [
                 TVPopupOption(id: "settings-popup-subtitle-manual", title: "Manual", isCurrent: subtitleMode == .manual, isDestructive: false) {
@@ -1165,6 +1201,17 @@ struct SettingsView: View {
                 Text("Stereo").tag("stereo")
             }
 
+            #if !DISPATCHERPVR
+            Picker("Live TV Quality", selection: $streamQuality) {
+                ForEach(StreamQuality.allCases) { quality in
+                    Text(quality.label).tag(quality)
+                }
+            }
+            Text(streamQualityDescription)
+                .font(.caption)
+                .foregroundStyle(Theme.textTertiary)
+            #endif
+
             Picker("Deinterlacing", selection: $deinterlaceMode) {
                 ForEach(DeinterlaceMode.allCases) { mode in
                     Text(mode.label).tag(mode)
@@ -1232,6 +1279,13 @@ struct SettingsView: View {
             prefs.deinterlaceMode = deinterlaceMode
             prefs.save()
         }
+        #if !DISPATCHERPVR
+        .onChange(of: streamQuality) { _ in
+            var prefs = UserPreferences.load()
+            prefs.streamQuality = streamQuality
+            prefs.save()
+        }
+        #endif
         .onChange(of: subtitleMode) { _ in
             var prefs = UserPreferences.load()
             prefs.subtitleMode = subtitleMode
@@ -1270,6 +1324,15 @@ struct SettingsView: View {
             return "Automatically select the last used subtitle language when available."
         }
     }
+
+    #if !DISPATCHERPVR
+    /// Explains the selected live TV quality. Like the other player settings
+    /// this takes effect on the next stream, since the profile is chosen when
+    /// the stream is opened.
+    private var streamQualityDescription: String {
+        streamQuality.summary + " Applies to the next channel you play."
+    }
+    #endif
 
     /// Explains the selected deinterlacing mode (#142). Changing the mode
     /// takes effect the next time playback starts, since mpv is configured

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -27,6 +27,9 @@ struct SettingsView: View {
     @State private var deinterlaceMode: DeinterlaceMode = UserPreferences.load().deinterlaceMode
     #if !DISPATCHERPVR
     @State private var streamQuality: StreamQuality = UserPreferences.load().streamQuality
+    #if !os(tvOS)
+    @State private var cellularStreamQuality: StreamQuality? = UserPreferences.load().cellularStreamQuality
+    #endif
     #endif
     @State private var landingTab: LandingTabOption = UserPreferences.load().landingTab
     @State private var hideRecordings: Bool = UserPreferences.load().hideRecordings
@@ -1210,6 +1213,18 @@ struct SettingsView: View {
             Text(streamQualityDescription)
                 .font(.caption)
                 .foregroundStyle(Theme.textTertiary)
+
+            #if !os(tvOS)
+            Picker("On Cellular", selection: $cellularStreamQuality) {
+                Text("Same as usual").tag(StreamQuality?.none)
+                ForEach(StreamQuality.allCases) { quality in
+                    Text(quality.label).tag(StreamQuality?.some(quality))
+                }
+            }
+            Text(cellularStreamQualityDescription)
+                .font(.caption)
+                .foregroundStyle(Theme.textTertiary)
+            #endif
             #endif
 
             Picker("Deinterlacing", selection: $deinterlaceMode) {
@@ -1285,6 +1300,13 @@ struct SettingsView: View {
             prefs.streamQuality = streamQuality
             prefs.save()
         }
+        #if !os(tvOS)
+        .onChange(of: cellularStreamQuality) { _ in
+            var prefs = UserPreferences.load()
+            prefs.cellularStreamQuality = cellularStreamQuality
+            prefs.save()
+        }
+        #endif
         #endif
         .onChange(of: subtitleMode) { _ in
             var prefs = UserPreferences.load()
@@ -1326,6 +1348,19 @@ struct SettingsView: View {
     }
 
     #if !DISPATCHERPVR
+    #if !os(tvOS)
+    /// Explains the metered-network override. "Metered" rather than "cellular"
+    /// because the rule also covers a personal hotspot and Low Data Mode.
+    private var cellularStreamQualityDescription: String {
+        guard let cellularStreamQuality else {
+            return "Live TV uses the quality above on every network."
+        }
+        return "Live TV switches to \(cellularStreamQuality.label) on cellular, a personal "
+            + "hotspot, or in Low Data Mode. Chosen when playback starts — changing network "
+            + "mid-programme doesn't interrupt the stream."
+    }
+    #endif
+
     /// Explains the selected live TV quality. Like the other player settings
     /// this takes effect on the next stream, since the profile is chosen when
     /// the stream is opened.

--- a/NexusPVRTests/StreamQualityTests.swift
+++ b/NexusPVRTests/StreamQualityTests.swift
@@ -1,0 +1,142 @@
+//
+//  StreamQualityTests.swift
+//  NexusPVRTests
+//
+//  Tests for the user-selectable live TV transcoding profile.
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct StreamQualityTests {
+
+    // MARK: - Profile mapping
+
+    @Test("Original never transcodes")
+    func originalIsDirect() {
+        #expect(StreamQuality.original.isTranscoded == false)
+        #expect(StreamQuality.original.profileName == nil)
+    }
+
+    @Test("Every other quality maps to a NextPVR profile name")
+    func qualitiesMapToProfiles() {
+        #expect(StreamQuality.p1080.profileName == "1080p")
+        #expect(StreamQuality.p720.profileName == "720p")
+        #expect(StreamQuality.p480.profileName == "480p")
+        #expect(StreamQuality.p144.profileName == "144p")
+
+        for quality in StreamQuality.allCases where quality != .original {
+            #expect(quality.isTranscoded)
+            #expect(quality.profileName == "\(quality.rawValue)p")
+        }
+    }
+
+    @Test("Options match the resolutions NextPVR servers ship profiles for")
+    func optionsMatchServerProfiles() {
+        #expect(StreamQuality.allCases.map(\.rawValue) == [
+            "Original", "1080", "720", "576", "504", "480", "360", "240", "144"
+        ])
+    }
+
+    @Test("Every option has a label and a summary")
+    func optionsAreLabelled() {
+        for quality in StreamQuality.allCases {
+            #expect(!quality.label.isEmpty)
+            #expect(!quality.summary.isEmpty)
+            #expect(!quality.icon.isEmpty)
+        }
+        #expect(StreamQuality.original.label == "Original")
+        #expect(StreamQuality.p720.label == "720p")
+    }
+
+    // MARK: - Persistence
+
+    @Test("Preferences default to the direct stream")
+    func defaultsToOriginal() {
+        #expect(UserPreferences().streamQuality == .original)
+    }
+
+    @Test("Preferences written before the setting existed decode to Original")
+    func legacyPreferencesDecodeToOriginal() throws {
+        // A blob from an older build: no streamQuality key at all. Decoding it
+        // to anything else would silently start transcoding on upgrade.
+        let json = #"{"keywords":[],"seekBackwardSeconds":10,"seekForwardSeconds":30}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.streamQuality == .original)
+    }
+
+    @Test("Quality survives an encode/decode round trip")
+    func roundTrips() throws {
+        var prefs = UserPreferences()
+        prefs.streamQuality = .p480
+        let data = try JSONEncoder().encode(prefs)
+        let decoded = try JSONDecoder().decode(UserPreferences.self, from: data)
+        #expect(decoded.streamQuality == .p480)
+    }
+
+    // MARK: - Transcode status parsing
+
+    @Test("A ready transcode parses")
+    func parsesReadyStatus() {
+        let xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rsp stat="ok">
+          <percentage>100</percentage>
+          <final>true</final>
+        </rsp>
+        """
+        let progress = NextPVRClient.parseTranscodeStatus(Data(xml.utf8))
+        #expect(progress?.percentage == 100)
+        #expect(progress?.isReady == true)
+        #expect(progress?.hasFailed == false)
+    }
+
+    @Test("A transcode still starting up is neither ready nor failed")
+    func parsesInProgressStatus() {
+        let xml = "<rsp stat=\"ok\"><percentage>40</percentage><final>false</final></rsp>"
+        let progress = NextPVRClient.parseTranscodeStatus(Data(xml.utf8))
+        #expect(progress?.isReady == false)
+        #expect(progress?.hasFailed == false)
+    }
+
+    @Test("A final status short of 100 is a failed transcode")
+    func parsesStalledStatus() {
+        // The server gave up — fall back to the direct stream rather than
+        // waiting out the full timeout.
+        let xml = "<rsp stat=\"ok\"><percentage>30</percentage><final>true</final></rsp>"
+        let progress = NextPVRClient.parseTranscodeStatus(Data(xml.utf8))
+        #expect(progress?.hasFailed == true)
+        #expect(progress?.isReady == false)
+    }
+
+    @Test("Missing final element defaults to not final")
+    func missingFinalDefaultsToFalse() {
+        let progress = NextPVRClient.parseTranscodeStatus(Data("<rsp><percentage>10</percentage></rsp>".utf8))
+        #expect(progress?.isFinal == false)
+    }
+
+    @Test("A document without a percentage yields no progress")
+    func parsesMissingPercentage() {
+        #expect(NextPVRClient.parseTranscodeStatus(Data("<rsp stat=\"ok\"/>".utf8)) == nil)
+    }
+
+    @Test("Malformed XML yields no progress rather than throwing")
+    func parsesMalformedDocument() {
+        #expect(NextPVRClient.parseTranscodeStatus(Data("not xml at all".utf8)) == nil)
+    }
+
+    // MARK: - Demo mode
+
+    @MainActor
+    @Test("Demo mode ignores the transcode setting")
+    func demoModeIsUnaffected() async throws {
+        let client = NextPVRClient(config: ServerConfig(host: "demo", pin: "", useHTTPS: false))
+        client.streamQualityOverride = .p360
+        try await client.authenticate()
+        let channels = try await client.getChannels()
+        let url = try await client.liveStreamURL(channelId: try #require(channels.first).id)
+        #expect(!url.absoluteString.contains("transcode"))
+        #expect(!client.hasActiveLiveStream)
+    }
+}

--- a/NexusPVRTests/StreamQualityTests.swift
+++ b/NexusPVRTests/StreamQualityTests.swift
@@ -126,6 +126,43 @@ struct StreamQualityTests {
         #expect(NextPVRClient.parseTranscodeStatus(Data("not xml at all".utf8)) == nil)
     }
 
+    // MARK: - Refusals
+
+    @Test("A hardware-encoder failure is read as a refusal, not as progress")
+    func detectsEncoderFailure() {
+        // Verbatim from a NextPVR server whose VAAPI render node was
+        // unreadable: ffmpeg exited immediately and the server reported this
+        // at HTTP 200. Treating it as anything but a failure leaves the user
+        // watching the full-bitrate stream with no indication why.
+        let xml = """
+        <rsp stat="fail">
+          <err code="11" msg="Failed to start requested stream" />
+        </rsp>
+        """
+        let failure = NextPVRClient.transcodeFailure(Data(xml.utf8))
+        #expect(failure == "Failed to start requested stream (err 11)")
+        // It carries no <percentage>, so it must not read as progress either.
+        #expect(NextPVRClient.parseTranscodeStatus(Data(xml.utf8)) == nil)
+    }
+
+    @Test("An accepted transcode is not reported as a refusal")
+    func acceptedTranscodeIsNotAFailure() {
+        #expect(NextPVRClient.transcodeFailure(Data(#"<rsp stat="ok"/>"#.utf8)) == nil)
+        let status = #"<rsp stat="ok"><percentage>100</percentage><final>true</final></rsp>"#
+        #expect(NextPVRClient.transcodeFailure(Data(status.utf8)) == nil)
+    }
+
+    @Test("A refusal without a code still yields the server's message")
+    func refusalWithoutCode() {
+        #expect(NextPVRClient.transcodeFailure(Data(#"<rsp stat="fail"><err msg="Unknown profile"/></rsp>"#.utf8))
+                == "Unknown profile")
+    }
+
+    @Test("Malformed XML is not mistaken for a refusal")
+    func malformedIsNotARefusal() {
+        #expect(NextPVRClient.transcodeFailure(Data("not xml".utf8)) == nil)
+    }
+
     // MARK: - Demo mode
 
     @MainActor

--- a/NexusPVRTests/StreamQualityTests.swift
+++ b/NexusPVRTests/StreamQualityTests.swift
@@ -126,6 +126,64 @@ struct StreamQualityTests {
         #expect(NextPVRClient.parseTranscodeStatus(Data("not xml at all".utf8)) == nil)
     }
 
+    // MARK: - Metered-network rule
+
+    @Test("The usual quality is used off a metered network")
+    func usesUsualQualityOnWiFi() {
+        #expect(NextPVRClient.effectiveStreamQuality(
+            usual: .original, cellular: .p360, onMeteredNetwork: false) == .original)
+        #expect(NextPVRClient.effectiveStreamQuality(
+            usual: .p720, cellular: .p144, onMeteredNetwork: false) == .p720)
+    }
+
+    @Test("The cellular quality is used on a metered network")
+    func usesCellularQualityWhenMetered() {
+        #expect(NextPVRClient.effectiveStreamQuality(
+            usual: .original, cellular: .p360, onMeteredNetwork: true) == .p360)
+    }
+
+    @Test("No cellular choice means the network makes no difference")
+    func noCellularChoiceChangesNothing() {
+        // The default. An upgrade must not start silently downgrading streams.
+        #expect(NextPVRClient.effectiveStreamQuality(
+            usual: .p720, cellular: nil, onMeteredNetwork: true) == .p720)
+        #expect(NextPVRClient.effectiveStreamQuality(
+            usual: .original, cellular: nil, onMeteredNetwork: true) == .original)
+    }
+
+    @Test("A cellular choice higher than usual is still honoured")
+    func cellularChoiceIsHonouredLiterally() {
+        // Odd, but it is an explicit per-network setting; quietly ignoring it
+        // would make the picker mean different things on different networks.
+        #expect(NextPVRClient.effectiveStreamQuality(
+            usual: .p240, cellular: .original, onMeteredNetwork: true) == .original)
+    }
+
+    @Test("The cellular quality round-trips and defaults to nil")
+    func cellularQualityPersists() throws {
+        #expect(UserPreferences().cellularStreamQuality == nil)
+
+        var prefs = UserPreferences()
+        prefs.cellularStreamQuality = .p360
+        let decoded = try JSONDecoder().decode(
+            UserPreferences.self, from: try JSONEncoder().encode(prefs))
+        #expect(decoded.cellularStreamQuality == .p360)
+
+        // Clearing it back to "same as usual" must persist as absent, not stick.
+        prefs.cellularStreamQuality = nil
+        let cleared = try JSONDecoder().decode(
+            UserPreferences.self, from: try JSONEncoder().encode(prefs))
+        #expect(cleared.cellularStreamQuality == nil)
+    }
+
+    @Test("Preferences from before the cellular rule decode to nil")
+    func legacyPreferencesHaveNoCellularRule() throws {
+        let json = #"{"keywords":[],"streamQuality":"720"}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.streamQuality == .p720)
+        #expect(prefs.cellularStreamQuality == nil)
+    }
+
     // MARK: - Refusals
 
     @Test("A hardware-encoder failure is read as a refusal, not as progress")

--- a/NexusPVRTests/StreamQualityTests.swift
+++ b/NexusPVRTests/StreamQualityTests.swift
@@ -175,5 +175,20 @@ struct StreamQualityTests {
         let url = try await client.liveStreamURL(channelId: try #require(channels.first).id)
         #expect(!url.absoluteString.contains("transcode"))
         #expect(!client.hasActiveLiveStream)
+        // Nothing was attempted, so nothing to warn about — the player must not
+        // show a fallback banner over a stream that is playing as asked.
+        #expect(client.streamQualityNotice == nil)
+    }
+
+    @MainActor
+    @Test("The fallback notice is cleared when a new stream starts")
+    func noticeIsClearedPerStream() async throws {
+        let client = NextPVRClient(config: ServerConfig(host: "demo", pin: "", useHTTPS: false))
+        try await client.authenticate()
+        let channels = try await client.getChannels()
+        _ = try await client.liveStreamURL(channelId: try #require(channels.first).id)
+        #expect(client.streamQualityNotice == nil)
+        client.clearStreamQualityNotice()
+        #expect(client.streamQualityNotice == nil)
     }
 }

--- a/mock-server-nextpvr/server.js
+++ b/mock-server-nextpvr/server.js
@@ -335,6 +335,21 @@ function hslToRgb(h, s, l) {
 
 const sessions = new Map();
 const LIVE_STREAM_TTL_MS = 15000;
+// Streaming profiles the mock "server admin" has defined. A profile outside
+// this list is rejected, so the client's fallback to the direct stream gets
+// exercised instead of only its happy path.
+const TRANSCODE_PROFILES = [
+  "1080p",
+  "720p",
+  "576p",
+  "504p",
+  "480p",
+  "360p",
+  "240p",
+  "144p",
+];
+// How long the mock takes to reach 100% readiness.
+const TRANSCODE_STARTUP_MS = 2000;
 
 function createSession() {
   const sid = crypto.randomUUID().replace(/-/g, "").substring(0, 32);
@@ -423,7 +438,7 @@ function handleRequest(req, res) {
   // how the wrong client shape gets caught here instead of on a user's server.
   if (
     method &&
-    (method.startsWith("channel.stream.") || method === "channel.transcode.lease")
+    (method.startsWith("channel.stream.") || method.startsWith("channel.transcode."))
   ) {
     if (url.pathname !== "/service") {
       return json(res, { stat: "fail", error: "Not found" }, 404);
@@ -440,6 +455,69 @@ function handleRequest(req, res) {
     ) {
       console.log("Live stream expired without renewal");
       delete session.liveStream;
+    }
+
+    // -- Server-side transcoding --
+    // NextPVR only transcodes when a client asks. initiate starts ffmpeg with a
+    // named profile, status counts to 100 while the first HLS segments fill, and
+    // m3u8 then serves the playlist. Mirrors Kodi's TranscodedBuffer flow.
+    if (method === "channel.transcode.initiate") {
+      const channelId = parseInt(url.searchParams.get("channel_id") || "0", 10);
+      const profile = url.searchParams.get("profile") || "";
+      if (!channelId) {
+        return xml(res, `<rsp stat="fail"><err code="1"/></rsp>`, 400);
+      }
+      // An unknown profile fails at 200, which is how a real server rejects a
+      // profile the admin has not defined — the client must read the body.
+      if (!TRANSCODE_PROFILES.includes(profile)) {
+        return xml(res, `<rsp stat="fail"><err code="2" msg="Unknown profile"/></rsp>`);
+      }
+      session.transcode = { channelId, profile, startedMs: Date.now() };
+      return xml(res, `<rsp stat="ok"/>`);
+    }
+
+    if (method === "channel.transcode.status") {
+      if (!session.transcode) {
+        return json(res, { stat: "fail", error: "No active transcode" }, 404);
+      }
+      // Ramp to 100 over TRANSCODE_STARTUP_MS so the client's readiness poll is
+      // exercised rather than short-circuited on the first tick.
+      const elapsed = Date.now() - session.transcode.startedMs;
+      const percentage = Math.min(
+        100,
+        Math.round((elapsed / TRANSCODE_STARTUP_MS) * 100)
+      );
+      return xml(
+        res,
+        `<?xml version="1.0" encoding="UTF-8"?>\n` +
+          `<rsp stat="ok">\n` +
+          `  <percentage>${percentage}</percentage>\n` +
+          `  <final>${percentage >= 100}</final>\n` +
+          `</rsp>\n`
+      );
+    }
+
+    if (method === "channel.transcode.stop") {
+      delete session.transcode;
+      return xml(res, `<rsp stat="ok"/>`);
+    }
+
+    if (method === "channel.transcode.m3u8") {
+      if (!session.transcode) {
+        return json(res, { stat: "fail", error: "No active transcode" }, 404);
+      }
+      // Shape only — like /live, this mock serves no actual media, so the
+      // playlist references a segment that isn't there.
+      const body =
+        `#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:10\n` +
+        `#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:10.0,\n` +
+        `/live?transcode=${session.transcode.profile}&segment=0\n`;
+      res.writeHead(200, {
+        "Content-Type": "application/x-mpegURL",
+        "Content-Length": Buffer.byteLength(body),
+      });
+      res.end(body);
+      return;
     }
 
     if (method === "channel.transcode.lease") {

--- a/mock-server-nextpvr/server.js
+++ b/mock-server-nextpvr/server.js
@@ -6,7 +6,7 @@
  * format so the NexusPVR client can connect without modification.
  *
  * Usage:
- *   node server.js [--channels 1000] [--port 8866]
+ *   node server.js [--channels 1000] [--port 8866] [--transcode-encoder-failure]
  *
  * Then configure the app to connect to http://<your-ip>:8866
  * with any PIN (default accepts all).
@@ -350,6 +350,9 @@ const TRANSCODE_PROFILES = [
 ];
 // How long the mock takes to reach 100% readiness.
 const TRANSCODE_STARTUP_MS = 2000;
+// --transcode-encoder-failure makes every transcode fail the way a broken
+// hardware encoder does, so the client's fallback can be exercised.
+const TRANSCODE_ENCODER_FAILURE = args.transcodeEncoderFailure || false;
 
 function createSession() {
   const sid = crypto.randomUUID().replace(/-/g, "").substring(0, 32);
@@ -471,6 +474,17 @@ function handleRequest(req, res) {
       // profile the admin has not defined — the client must read the body.
       if (!TRANSCODE_PROFILES.includes(profile)) {
         return xml(res, `<rsp stat="fail"><err code="2" msg="Unknown profile"/></rsp>`);
+      }
+      // With --transcode-encoder-failure, accept the request and then report
+      // the encoder dying, the way a real server does when its hardware
+      // encoder can't be opened: ffmpeg is spawned, exits immediately, and the
+      // failure comes back at HTTP 200. Observed on a NextPVR box whose VAAPI
+      // render node was unreadable inside its container.
+      if (TRANSCODE_ENCODER_FAILURE) {
+        return xml(
+          res,
+          `<rsp stat="fail">\n  <err code="11" msg="Failed to start requested stream" />\n</rsp>`
+        );
       }
       session.transcode = { channelId, profile, startedMs: Date.now() };
       return xml(res, `<rsp stat="ok"/>`);
@@ -683,6 +697,8 @@ function parseArgs() {
       result.channels = parseInt(argv[++i], 10);
     } else if (argv[i] === "--port" && argv[i + 1]) {
       result.port = parseInt(argv[++i], 10);
+    } else if (argv[i] === "--transcode-encoder-failure") {
+      result.transcodeEncoderFailure = true;
     } else if (argv[i] === "--days-before" && argv[i + 1]) {
       result.daysBefore = parseInt(argv[++i], 10);
     } else if (argv[i] === "--days-after" && argv[i + 1]) {


### PR DESCRIPTION
## Why

Live TV always streamed the raw `/live` transport stream, so a broadcast played
at its full bitrate no matter the connection — 2.5–3.0 Mbps for 720p, which
isn't sustainable on a weak cellular link. NextPVR can transcode, but only when
a client asks: the profile is requested per stream, so each device can choose
its own.

## What

A **Live TV Quality** setting (Original, 1080p … 144p) that switches
`liveStreamURL` to Kodi's `Transcoded` streaming method:

```
channel.transcode.initiate&force=true&channel_id=N&profile=144p
→ poll channel.transcode.status until 100%
→ play channel.transcode.m3u8   (HLS)
→ channel.transcode.stop on teardown
```

- **Defaults to Original**, so nothing changes for existing users and no server
  starts transcoding unasked. Preferences written by older builds decode to
  Original.
- **Any failure falls back to the direct stream** rather than failing playback:
  an undefined profile, a server too slow to keep up, a stalled transcode.
- **The fallback is not silent.** The player shows a transient banner ("The
  server couldn't transcode to 144p — playing at original quality") and the full
  reason goes to the in-app event log.
- **NextPVR only** — gated out of the Dispatcharr variant, where the new
  protocol members take nil/no-op defaults.

### Automatic downgrade on metered networks

A separate **On Cellular** picker. Set it and live TV uses that quality on a
metered network and the usual one everywhere else — which is what the original
problem actually needed, since remembering to change quality *before* reaching a
bad spot isn't realistic.

Keyed on `NWPath.isExpensive` / `isConstrained` rather than the interface type,
so it also covers a personal hotspot and Low Data Mode. Defaults to "Same as
usual", so an upgrade never silently downgrades anyone. Evaluated when the stream
opens — changing network mid-programme doesn't re-negotiate, which would mean
tearing down playback under the user. The player says "On a metered network —
playing at 360p" when the rule changes the quality. Hidden on tvOS.

The cellular choice is honoured literally, including when it is *higher* than the
usual one. It's an explicit per-network setting, and quietly ignoring it would
make the picker mean different things on different networks.

### Pause and seek on live TV are Original-only

A transcoded stream is HLS, not the timeshift buffer, so the byte-offset seek in
`liveStreamSeekURL` doesn't apply. The keepalive is skipped for transcoded
streams too — Kodi's `TranscodedBuffer` overrides `Lease()` to a no-op for the
same reason; the player's own playlist requests keep the stream alive, and
sending `channel.transcode.lease` would just 404 every tick.

### The bitrate at each rung belongs to the server

The client sends a profile *name*; NextPVR maps it to ffmpeg arguments in
`<StreamingProfiles>` in `config.xml`. An admin who wants a different bitrate at
480p changes it there, not here.

## A note on diagnostics

The first cut fell back silently and the feature looked broken. It wasn't — the
server was refusing every transcode — but nothing said so, because NextPVR
reports these refusals at **HTTP 200**: it accepts the request, spawns ffmpeg,
and only discovers the encode can't run once ffmpeg exits. `loggedData` records a
response body only for non-2xx, so the event log showed initiate succeeding while
no transcode existed. Refusals are now parsed out of `stat`/`<err>` and reported
in the server's own words, and a `stat="fail"` arriving mid-poll is terminal
instead of burning the full 30s timeout.

## Verification

- 53 tests pass. The metered-network rule is a pure function
  (`effectiveStreamQuality`) so it's covered without a network, including the
  default-off case and preferences written before the rule existed.
  The refusal test uses the verbatim document a real server
  returned when its VAAPI render node was unreadable inside its LXC container
  (`err code="11" msg="Failed to start requested stream"`), and the mock
  reproduces that shape under `--transcode-encoder-failure`.
- NextPVR iOS, NextPVR tvOS (Top Shelf included), and Dispatcharr all build clean.
- The protocol was driven end-to-end against the mock server by hand.
- **The success path is confirmed against a real server and real hardware**: with
  144p selected the server encodes `h264_vaapi 256x144 @ 100 kb/s` plus
  `aac 128 kb/s`, writes HLS segments, and the app fetches
  `channel.transcode.m3u8` and plays it — 100 kb/s video against the 2.5–3.0 Mbps
  the direct stream was using, at 2.4–18× realtime encode speed.

## Also included

One commit corrects three stale claims in `CLAUDE.md` found while building this:
the Dispatcharr scheme name (`Dispatcharr`, not `DispatcharrPVR` — the documented
name fails outright), the XcodeBuildMCP tool names, and a reference to XcodeGen
and a `project.yml` that don't exist.

