### PR TITLE
Let a single Back press exit the app from the tvOS home screen (#155)

### DIFF
--- a/NexusPVR/Navigation/NavigationRouter.swift
+++ b/NexusPVR/Navigation/NavigationRouter.swift
@@ -1227,30 +1227,7 @@ struct TVOSNavigation: View {
         }
         .animation(.easeInOut(duration: 0.25), value: sidebarEnabled)
         .background(.ultraThinMaterial)
-        .onExitCommand {
-            if appState.selectedTab == .settings {
-                if appState.tvosSettingsHasPopup {
-                    appState.tvosSettingsDismissPopupRequest += 1
-                    return
-                }
-                if appState.tvosSettingsShowingEventLog {
-                    appState.tvosSettingsDismissEventLogRequest += 1
-                    return
-                }
-                focusSidebar()
-                return
-            }
-            #if DISPATCHERPVR
-            if appState.selectedTab == .stats {
-                focusSidebar()
-                return
-            }
-            #endif
-            if appState.tvosBlocksSidebarExitCommand {
-                return
-            }
-            focusSidebar()
-        }
+        .onExitCommand(perform: rootExitHandler)
         .onAppear {
             focusedItem = preferredSidebarFocusItem()
             appState.topicKeywords = UserPreferences.load().keywords
@@ -1292,6 +1269,36 @@ struct TVOSNavigation: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .restoreFromPiP)) { _ in
             appState.isShowingPlayer = true
+        }
+    }
+
+    private var rootExitAction: TVRootExitAction {
+        TVRootExitAction.resolve(
+            selectedTab: appState.selectedTab,
+            sidebarHasFocus: focusedItem != nil,
+            settingsHasPopup: appState.tvosSettingsHasPopup,
+            settingsShowingEventLog: appState.tvosSettingsShowingEventLog,
+            blocksSidebarExit: appState.tvosBlocksSidebarExitCommand
+        )
+    }
+
+    /// A `nil` handler leaves the Back press unhandled so tvOS returns to
+    /// the app launcher when the sidebar already has focus (#155).
+    private var rootExitHandler: (() -> Void)? {
+        if rootExitAction == .exitToSystem { return nil }
+        return { handleRootExitCommand() }
+    }
+
+    private func handleRootExitCommand() {
+        switch rootExitAction {
+        case .dismissSettingsPopup:
+            appState.tvosSettingsDismissPopupRequest += 1
+        case .dismissEventLog:
+            appState.tvosSettingsDismissEventLogRequest += 1
+        case .focusSidebar:
+            focusSidebar()
+        case .ignore, .exitToSystem:
+            break
         }
     }
 

--- a/NexusPVR/Navigation/TVRootExitAction.swift
+++ b/NexusPVR/Navigation/TVRootExitAction.swift
@@ -1,0 +1,53 @@
+//
+//  TVRootExitAction.swift
+//  NexusPVR
+//
+//  Decides what the tvOS root navigation does with a Siri Remote Back
+//  (exit command) press. Kept platform-independent so it can be unit tested
+//  from the iOS test target.
+//
+
+import Foundation
+
+/// The action the tvOS root navigation takes for one Back press.
+nonisolated enum TVRootExitAction: Equatable {
+    /// Close the Settings option popup.
+    case dismissSettingsPopup
+    /// Close the Settings event log.
+    case dismissEventLog
+    /// Move focus from the content area back to the sidebar.
+    case focusSidebar
+    /// Consume the press without doing anything (a child view owns it).
+    case ignore
+    /// Leave the press unhandled so tvOS returns to the app launcher (#155).
+    case exitToSystem
+
+    /// Resolves the action for the current navigation state.
+    ///
+    /// Priority mirrors standard tvOS behaviour: dismiss overlays first, then
+    /// step back inside the app, and only when there is nothing left to
+    /// dismiss hand the press to the system so a single tap leaves the app.
+    ///
+    /// - Parameters:
+    ///   - selectedTab: the tab currently shown in the content area.
+    ///   - sidebarHasFocus: whether a sidebar item currently holds focus.
+    ///   - settingsHasPopup: whether the Settings option popup is open.
+    ///   - settingsShowingEventLog: whether the Settings event log is open.
+    ///   - blocksSidebarExit: whether a child view asked the root to leave the
+    ///     press alone (`AppState.tvosBlocksSidebarExitCommand`).
+    static func resolve(
+        selectedTab: Tab,
+        sidebarHasFocus: Bool,
+        settingsHasPopup: Bool,
+        settingsShowingEventLog: Bool,
+        blocksSidebarExit: Bool
+    ) -> TVRootExitAction {
+        if selectedTab == .settings {
+            if settingsHasPopup { return .dismissSettingsPopup }
+            if settingsShowingEventLog { return .dismissEventLog }
+        } else if blocksSidebarExit {
+            return .ignore
+        }
+        return sidebarHasFocus ? .exitToSystem : .focusSidebar
+    }
+}

--- a/NexusPVRTests/TVRootExitActionTests.swift
+++ b/NexusPVRTests/TVRootExitActionTests.swift
@@ -1,0 +1,66 @@
+//
+//  TVRootExitActionTests.swift
+//  NexusPVRTests
+//
+//  Tests for the tvOS root Back-button decision (#155).
+//
+
+import Testing
+@testable import NextPVR
+
+struct TVRootExitActionTests {
+
+    private func resolve(
+        tab: Tab = .guide,
+        sidebarHasFocus: Bool = false,
+        popup: Bool = false,
+        eventLog: Bool = false,
+        blocks: Bool = false
+    ) -> TVRootExitAction {
+        TVRootExitAction.resolve(
+            selectedTab: tab,
+            sidebarHasFocus: sidebarHasFocus,
+            settingsHasPopup: popup,
+            settingsShowingEventLog: eventLog,
+            blocksSidebarExit: blocks
+        )
+    }
+
+    @Test("Back with sidebar focused hands the press to the system")
+    func sidebarFocusedExitsApp() {
+        for tab in [Tab.guide, .channels, .recordings, .topics, .search, .settings] {
+            #expect(resolve(tab: tab, sidebarHasFocus: true) == .exitToSystem)
+        }
+    }
+
+    @Test("Back from content moves focus to the sidebar")
+    func contentFocusedGoesToSidebar() {
+        for tab in [Tab.guide, .channels, .recordings, .topics, .search, .settings] {
+            #expect(resolve(tab: tab, sidebarHasFocus: false) == .focusSidebar)
+        }
+    }
+
+    @Test("Settings popup is dismissed before anything else")
+    func settingsPopupWins() {
+        #expect(resolve(tab: .settings, sidebarHasFocus: true, popup: true, eventLog: true) == .dismissSettingsPopup)
+        #expect(resolve(tab: .settings, popup: true, blocks: true) == .dismissSettingsPopup)
+    }
+
+    @Test("Settings event log is dismissed before leaving the app")
+    func settingsEventLogDismissed() {
+        #expect(resolve(tab: .settings, sidebarHasFocus: true, eventLog: true) == .dismissEventLog)
+        #expect(resolve(tab: .settings, eventLog: true, blocks: true) == .dismissEventLog)
+    }
+
+    @Test("Settings ignores the sidebar block flag once overlays are closed")
+    func settingsIgnoresBlockFlag() {
+        #expect(resolve(tab: .settings, blocks: true) == .focusSidebar)
+        #expect(resolve(tab: .settings, sidebarHasFocus: true, blocks: true) == .exitToSystem)
+    }
+
+    @Test("Other tabs consume the press while a child view blocks it")
+    func blockFlagIgnoresPress() {
+        #expect(resolve(tab: .guide, blocks: true) == .ignore)
+        #expect(resolve(tab: .guide, sidebarHasFocus: true, blocks: true) == .ignore)
+    }
+}


### PR DESCRIPTION
Fixes #155

## Problem

On Apple TV, pressing Back once on the app's top-level screen did nothing. The root `TVOSNavigation` view's `onExitCommand` handler always ran, even when the sidebar already had focus, so it consumed the press and users had to hold Back to return to the launcher.

## Fix

- New `TVRootExitAction` enum (`NexusPVR/Navigation/TVRootExitAction.swift`) resolves what the root should do for a Back press: dismiss the Settings popup, dismiss the event log, move focus from content to the sidebar, ignore (a child view owns it), or exit to the system.
- `TVOSNavigation` now passes `nil` to `onExitCommand` when the resolved action is exit-to-system. The press is left unhandled and tvOS returns to the app launcher on a single tap.
- All other Back behaviour is unchanged: Settings overlays dismiss first, content still hands focus back to the sidebar, the `tvosBlocksSidebarExitCommand` flag is still honoured, and the player's own handler inside its full-screen cover is untouched.

## Testing

- Added `TVRootExitActionTests` (6 Swift Testing cases) covering overlay priority, content vs. sidebar focus, and the block flag. Passing on the iPhone 17 Pro simulator.
- NextPVR scheme builds for the Apple TV simulator.
- Not yet verified on a physical Apple TV or with the Dispatcharr scheme.

