### PR TITLE
Add Dispatcharr Output Profile support to live playback (#161)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ Stored in `UserPreferences` struct (Core/Models/UserPreferences.swift), synced v
 - `keywords` - Topic keywords for program matching
 - `seekBackwardSeconds` - Default 10
 - `seekForwardSeconds` - Default 30
+- `outputProfileId` - Dispatcharr Output Profile for live TV (#161); nil = Original. `DispatcherClient.liveStreamURL` validates it against `/api/core/outputprofiles/` and appends `?output_profile=<id>`, falling back to the plain URL with a `streamQualityNotice` when unavailable
 
 Also defines `PlayerStats` struct for MPV playback statistics.
 

--- a/NexusPVR/AppEntry.swift
+++ b/NexusPVR/AppEntry.swift
@@ -219,14 +219,12 @@ struct PVRApp: App {
                     let channels = try await client.getChannels()
                     let channel = channels.first(where: { $0.id == id })
                     let channelName = channel?.name ?? "Channel \(id)"
-                    // Prefer direct stream URL from channel data (same as ProgramDetailView)
-                    let streamURL: URL
-                    if let directURL = channel?.streamURL, let url = URL(string: directURL) {
-                        streamURL = url
-                    } else {
-                        streamURL = try await appState.preparingStream {
-                            try await client.liveStreamURL(channelId: id)
-                        }
+                    // Always go through `client.liveStreamURL(channelId:)` rather
+                    // than the raw `channel.streamURL`: the client is what applies
+                    // the stream quality / output profile the user picked (#161),
+                    // and every other live entry point already does the same.
+                    let streamURL = try await appState.preparingStream {
+                        try await client.liveStreamURL(channelId: id)
                     }
                     appState.playStream(url: streamURL, title: channelName, channelId: id, channelName: channelName)
                 } catch {

--- a/NexusPVR/Core/Models/DispatcharrOutputProfile.swift
+++ b/NexusPVR/Core/Models/DispatcharrOutputProfile.swift
@@ -1,0 +1,100 @@
+//
+//  DispatcharrOutputProfile.swift
+//  DispatcherPVR
+//
+//  A Dispatcharr Output Profile (#161): a post-delivery FFmpeg remux or
+//  transcode step the server applies to a live stream for one client. Distinct
+//  from a Stream Profile, which controls how Dispatcharr *acquires* the
+//  provider stream. Listed by `GET /api/core/outputprofiles/`; requested on a
+//  live URL with `?output_profile=<id>`.
+//
+
+import Foundation
+
+nonisolated struct DispatcharrOutputProfile: Identifiable, Decodable, Sendable, Hashable {
+    let id: Int
+    let name: String
+    /// Dispatcharr only honours `?output_profile=` for active profiles, so an
+    /// inactive one must be treated as unavailable rather than sent.
+    let isActive: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case isActive = "is_active"
+    }
+
+    init(id: Int, name: String, isActive: Bool = true) {
+        self.id = id
+        self.name = name
+        self.isActive = isActive
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Profile #\(id)"
+        // Older payloads may omit the flag; a listed profile is active by default.
+        isActive = try container.decodeIfPresent(Bool.self, forKey: .isActive) ?? true
+    }
+
+    /// Query parameter name Dispatcharr's live proxy reads.
+    static let queryItemName = "output_profile"
+
+    /// Appends `?output_profile=<id>` to a live stream URL, keeping every
+    /// existing query item (a catch-up `session_id`, an XC `output=`) intact.
+    /// Nil `profileId` — the Original / pass-through choice — returns the URL
+    /// untouched, so the default produces exactly the pre-#161 URLs.
+    static func applying(profileId: Int?, to url: URL) -> URL {
+        guard let profileId,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == queryItemName }
+        items.append(URLQueryItem(name: queryItemName, value: String(profileId)))
+        components.queryItems = items
+        return components.url ?? url
+    }
+
+    /// Outcome of matching the user's saved choice against what the connected
+    /// server offers.
+    enum Resolution: Equatable, Sendable {
+        /// Original / pass-through: send no `output_profile` at all.
+        case original
+        /// Send `output_profile=<id>` for this active profile.
+        case profile(DispatcharrOutputProfile)
+        /// The saved id isn't an active profile on this server (deleted,
+        /// deactivated, or the endpoint couldn't be read). Play the original
+        /// stream and tell the user why.
+        case unavailable(profileId: Int, notice: String)
+
+        /// Id to put on the URL, nil for anything that plays the original.
+        var profileId: Int? {
+            if case .profile(let profile) = self { return profile.id }
+            return nil
+        }
+
+        var notice: String? {
+            if case .unavailable(_, let notice) = self { return notice }
+            return nil
+        }
+    }
+
+    /// Decides what to send for `selectedId`, given the active profiles the
+    /// server currently reports (`available` is nil when the list couldn't be
+    /// fetched — an older server, or an account without API access).
+    static func resolve(selectedId: Int?, available: [DispatcharrOutputProfile]?) -> Resolution {
+        guard let selectedId else { return .original }
+        if let match = available?.first(where: { $0.id == selectedId && $0.isActive }) {
+            return .profile(match)
+        }
+        let notice: String
+        if available == nil {
+            notice = "Couldn't read the server's output profiles — playing the original stream."
+        } else {
+            notice = "Output profile #\(selectedId) is no longer available on this server — "
+                + "playing the original stream."
+        }
+        return .unavailable(profileId: selectedId, notice: notice)
+    }
+}

--- a/NexusPVR/Core/Models/UserPreferences.swift
+++ b/NexusPVR/Core/Models/UserPreferences.swift
@@ -31,6 +31,13 @@ nonisolated struct UserPreferences: Codable {
     /// (cellular, personal hotspot, or Low Data Mode). Nil means "same as
     /// usual" — the default, so an upgrade changes nothing until asked.
     var cellularStreamQuality: StreamQuality? = nil
+    /// Dispatcharr Output Profile requested on live TV URLs (#161). Nil is
+    /// Original / pass-through — the default, which leaves every live URL
+    /// exactly as before. Unused by the NextPVR variant, which has its own
+    /// server-side transcoding via `streamQuality`. Stored as the server's
+    /// profile id, so the choice is validated against the connected server's
+    /// active profiles at play time rather than trusted blindly.
+    var outputProfileId: Int? = nil
     /// User-selectable tvOS UI font size (#107). Default `.medium`
     /// preserves the pre-feature visual output exactly — existing
     /// users see zero change on first launch after upgrade.
@@ -191,6 +198,7 @@ nonisolated struct UserPreferences: Codable {
         case deinterlaceMode
         case streamQuality
         case cellularStreamQuality
+        case outputProfileId
         case uiFontSize
         case preferredSubtitleLanguage
         case guideShowGroupsInSidebar
@@ -231,6 +239,8 @@ nonisolated struct UserPreferences: Codable {
         // upgrade never silently starts transcoding on someone's server.
         streamQuality = try container.decodeIfPresent(StreamQuality.self, forKey: .streamQuality) ?? .original
         cellularStreamQuality = try container.decodeIfPresent(StreamQuality.self, forKey: .cellularStreamQuality)
+        // Prefs written before #161 have no `outputProfileId`: Original.
+        outputProfileId = try container.decodeIfPresent(Int.self, forKey: .outputProfileId)
         // Forward- and backward-compat: a blob without `uiFontSize`
         // (any prefs written before #107) decodes to .medium so
         // existing users see no visual change.
@@ -261,6 +271,7 @@ nonisolated struct UserPreferences: Codable {
         try container.encode(deinterlaceMode, forKey: .deinterlaceMode)
         try container.encode(streamQuality, forKey: .streamQuality)
         try container.encodeIfPresent(cellularStreamQuality, forKey: .cellularStreamQuality)
+        try container.encodeIfPresent(outputProfileId, forKey: .outputProfileId)
         try container.encode(uiFontSize, forKey: .uiFontSize)
         try container.encodeIfPresent(preferredSubtitleLanguage, forKey: .preferredSubtitleLanguage)
         try container.encode(guideShowGroupsInSidebar, forKey: .guideShowGroupsInSidebar)

--- a/NexusPVR/Core/Services/DispatcherClient.swift
+++ b/NexusPVR/Core/Services/DispatcherClient.swift
@@ -51,6 +51,15 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
     /// Dispatcharr 0.24.0 stopped sending `m3u_profile_name` in /proxy/ts/status,
     /// so we resolve names client-side from the M3U accounts endpoint.
     private var m3uProfileNameCache: [Int: String] = [:]
+    /// Active Output Profiles reported by `/api/core/outputprofiles/` (#161).
+    /// Nil until a fetch succeeds, so "the endpoint isn't available" can be
+    /// told apart from "the server has no profiles". Published so the Settings
+    /// picker refreshes when the list arrives.
+    @Published private(set) var outputProfiles: [DispatcharrOutputProfile]?
+    /// Set when the last `liveStreamURL(channelId:)` could not honour the
+    /// user's chosen output profile and fell back to the original stream. The
+    /// player shows it once (see `PVRClientProtocol`); nil when nothing to say.
+    @Published private(set) var streamQualityNotice: String?
 
     init(config: ServerConfig? = nil, networkEventLogger: some NetworkEventLogging = Dependencies.networkEventLog) {
         self.config = config ?? ServerConfig.load()
@@ -86,6 +95,8 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         epgDataIdToChannelIds = [:]
         channelIdToUUID = [:]
         uuidToChannelId = [:]
+        outputProfiles = nil
+        streamQualityNotice = nil
         isAuthenticated = false
     }
 
@@ -1601,8 +1612,34 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
     // MARK: - Streaming URLs
 
     func liveStreamURL(channelId: Int) async throws -> URL {
+        streamQualityNotice = nil
         guard !config.isDemoMode else { return DemoDataProvider.demoVideoURL }
 
+        let baseStreamURL = try baseLiveStreamURL(channelId: channelId)
+
+        // Output Profile (#161): validated against the server's active list on
+        // every play so a deleted or deactivated profile degrades to the
+        // original stream with a visible reason instead of a silent no-op.
+        let resolution = await resolveOutputProfile(selectedId: UserPreferences.load().outputProfileId)
+        if let notice = resolution.notice {
+            streamQualityNotice = notice
+            networkEventLogger.log(NetworkEvent(
+                timestamp: Date(),
+                method: "GET",
+                path: "/proxy/ts/stream (output profile fallback)",
+                statusCode: nil,
+                isSuccess: false,
+                durationMs: 0,
+                responseSize: 0,
+                errorDetail: notice
+            ))
+        }
+        return DispatcharrOutputProfile.applying(profileId: resolution.profileId, to: baseStreamURL)
+    }
+
+    /// The live URL before any output-profile query is applied — the exact
+    /// URLs the app used before #161.
+    private func baseLiveStreamURL(channelId: Int) throws -> URL {
         if useOutputEndpoints {
             // XC credentials: use /live/{user}/{pass}/{id}
             if !config.password.isEmpty && !config.username.isEmpty && config.apiKey.isEmpty {
@@ -1632,6 +1669,53 @@ final class DispatcherClient: ObservableObject, PVRClientProtocol {
         }
 
         return url
+    }
+
+    // MARK: - Output Profiles (#161)
+
+    /// Fetches the server's Output Profiles, keeping only active ones, and
+    /// caches them. Throws when the endpoint can't be read (older Dispatcharr,
+    /// or an account without API access) so callers can distinguish that from
+    /// an empty list.
+    @discardableResult
+    func getOutputProfiles() async throws -> [DispatcharrOutputProfile] {
+        guard !config.isDemoMode || config.isMockServer else {
+            outputProfiles = []
+            return []
+        }
+        // Streamer-level XC accounts have no REST token to call the API with.
+        if useOutputEndpoints && accessToken == nil {
+            throw PVRClientError.apiError("Output profiles need API access")
+        }
+        guard let url = URL(string: "\(baseURL)/api/core/outputprofiles/") else {
+            throw PVRClientError.invalidResponse
+        }
+        let all: [DispatcharrOutputProfile] = try await fetchAllPages(url)
+        let active = all.filter(\.isActive)
+        outputProfiles = active
+        return active
+    }
+
+    /// Ensures the profile cache is populated, fetching if needed. Failures are
+    /// swallowed: the picker then shows only Original, and playback falls back.
+    func ensureOutputProfilesLoaded() async {
+        guard outputProfiles == nil else { return }
+        _ = try? await getOutputProfiles()
+    }
+
+    /// Matches the saved choice against the server's active profiles,
+    /// refreshing the cache when the saved id isn't in it (a profile created
+    /// since the last fetch should work without a relaunch).
+    private func resolveOutputProfile(selectedId: Int?) async -> DispatcharrOutputProfile.Resolution {
+        guard let selectedId else { return .original }
+        if outputProfiles?.contains(where: { $0.id == selectedId }) != true {
+            _ = try? await getOutputProfiles()
+        }
+        return DispatcharrOutputProfile.resolve(selectedId: selectedId, available: outputProfiles)
+    }
+
+    func clearStreamQualityNotice() {
+        streamQualityNotice = nil
     }
 
     func recordingStreamURL(recordingId: Int) async throws -> URL {

--- a/NexusPVR/Features/Settings/SettingsView.swift
+++ b/NexusPVR/Features/Settings/SettingsView.swift
@@ -42,6 +42,8 @@ struct SettingsView: View {
     #if DISPATCHERPVR
     @State private var guideShowProfilesInSidebar: Bool = UserPreferences.load().guideShowProfilesInSidebar
     @State private var guideProfileIds: [Int] = UserPreferences.load().guideProfileIds
+    /// Selected Dispatcharr Output Profile id (#161); nil is Original.
+    @State private var outputProfileId: Int? = UserPreferences.load().outputProfileId
     #endif
     @ObservedObject private var eventLog: NetworkEventLog
 
@@ -71,6 +73,8 @@ struct SettingsView: View {
         case deinterlace
         #if !DISPATCHERPVR
         case streamQuality
+        #else
+        case outputProfile
         #endif
         case renderer
         case landingTab
@@ -116,6 +120,11 @@ struct SettingsView: View {
             #endif
         }
         .accessibilityIdentifier("settings-view")
+        #if DISPATCHERPVR
+        .task {
+            await client.ensureOutputProfilesLoaded()
+        }
+        #endif
         #if os(tvOS)
         .background(.ultraThinMaterial)
         #else
@@ -237,6 +246,15 @@ struct SettingsView: View {
                                 detail: streamQualityDescription
                             ) {
                                 activeTVPopup = .streamQuality
+                            }
+                            #else
+                            tvSettingsRow(
+                                title: "Live TV Output Profile",
+                                value: outputProfileLabel,
+                                icon: "waveform.path.ecg.rectangle",
+                                detail: outputProfileDescription
+                            ) {
+                                activeTVPopup = .outputProfile
                             }
                             #endif
                             tvSettingsRow(
@@ -800,6 +818,9 @@ struct SettingsView: View {
         #if !DISPATCHERPVR
         case .streamQuality:
             return "Live TV Quality"
+        #else
+        case .outputProfile:
+            return "Live TV Output Profile"
         #endif
         case .subtitleMode:
             return "Subtitles"
@@ -906,6 +927,18 @@ struct SettingsView: View {
                     var prefs = UserPreferences.load()
                     prefs.streamQuality = quality
                     prefs.save()
+                }
+            }
+        #else
+        case .outputProfile:
+            return outputProfileChoices.map { choice in
+                TVPopupOption(
+                    id: "settings-popup-output-profile-\(choice.id.map(String.init) ?? "original")",
+                    title: choice.label,
+                    isCurrent: outputProfileId == choice.id,
+                    isDestructive: false
+                ) {
+                    saveOutputProfile(choice.id)
                 }
             }
         #endif
@@ -1224,6 +1257,15 @@ struct SettingsView: View {
                 .font(.caption)
                 .foregroundStyle(Theme.textTertiary)
             #endif
+            #else
+            Picker("Live TV Output Profile", selection: $outputProfileId) {
+                ForEach(outputProfileChoices) { choice in
+                    Text(choice.label).tag(choice.id)
+                }
+            }
+            Text(outputProfileDescription)
+                .font(.caption)
+                .foregroundStyle(Theme.textTertiary)
             #endif
 
             Picker("Deinterlacing", selection: $deinterlaceMode) {
@@ -1306,6 +1348,10 @@ struct SettingsView: View {
             prefs.save()
         }
         #endif
+        #else
+        .onChange(of: outputProfileId) { _ in
+            saveOutputProfile(outputProfileId)
+        }
         #endif
         .onChange(of: subtitleMode) { _ in
             var prefs = UserPreferences.load()
@@ -1365,6 +1411,61 @@ struct SettingsView: View {
     /// the stream is opened.
     private var streamQualityDescription: String {
         streamQuality.summary + " Applies to the next channel you play."
+    }
+    #endif
+
+    #if DISPATCHERPVR
+    /// One row of the Output Profile picker (#161). `id` nil is Original.
+    private struct OutputProfileChoice: Identifiable {
+        let id: Int?
+        let label: String
+    }
+
+    /// Original plus every active profile the server reports. When the saved
+    /// id isn't among them (deleted server-side, or the list couldn't be read)
+    /// it's kept as an explicit "unavailable" row so the picker never shows a
+    /// blank selection and the user can see what will fall back.
+    private var outputProfileChoices: [OutputProfileChoice] {
+        var choices = [OutputProfileChoice(id: nil, label: "Original")]
+        let profiles = client.outputProfiles ?? []
+        choices += profiles.map { OutputProfileChoice(id: $0.id, label: $0.name) }
+        if let outputProfileId, !profiles.contains(where: { $0.id == outputProfileId }) {
+            choices.append(OutputProfileChoice(id: outputProfileId, label: "Profile #\(outputProfileId) (unavailable)"))
+        }
+        return choices
+    }
+
+    private var outputProfileLabel: String {
+        outputProfileChoices.first(where: { $0.id == outputProfileId })?.label ?? "Original"
+    }
+
+    /// Explains the selected output profile. Like the other player settings
+    /// this takes effect on the next stream, since the URL is built when the
+    /// stream is opened.
+    private var outputProfileDescription: String {
+        guard let outputProfileId else {
+            return "Streams live TV exactly as Dispatcharr delivers it, with no extra "
+                + "server-side processing. Applies to the next channel you play."
+        }
+        if client.outputProfiles?.contains(where: { $0.id == outputProfileId }) == true {
+            return "Dispatcharr runs this profile's FFmpeg step on live TV before sending it "
+                + "to this device, trading server CPU for a client-friendly stream. "
+                + "Applies to the next channel you play."
+        }
+        if client.outputProfiles == nil {
+            return "This server didn't return its output profiles — it may be an older "
+                + "Dispatcharr, or this account may lack API access. Live TV plays the "
+                + "original stream until a profile can be verified."
+        }
+        return "This profile is no longer active on the server. Live TV plays the "
+            + "original stream until you pick another."
+    }
+
+    private func saveOutputProfile(_ id: Int?) {
+        outputProfileId = id
+        var prefs = UserPreferences.load()
+        prefs.outputProfileId = id
+        prefs.save()
     }
     #endif
 

--- a/NexusPVRTests/OutputProfileTests.swift
+++ b/NexusPVRTests/OutputProfileTests.swift
@@ -1,0 +1,166 @@
+//
+//  OutputProfileTests.swift
+//  NexusPVRTests
+//
+//  Tests for Dispatcharr Output Profile selection on live TV (#161):
+//  decoding, URL construction, Original behaviour, fallback, persistence.
+//
+
+import Testing
+import Foundation
+@testable import NextPVR
+
+struct OutputProfileTests {
+
+    // MARK: - Decoding
+
+    @Test("Decodes the fields Dispatcharr's serializer sends")
+    func decodesProfile() throws {
+        let json = #"{"id":3,"name":"Apple TV","command":"ffmpeg","parameters":"-c:v copy","is_active":true,"locked":false}"#
+        let profile = try JSONDecoder().decode(DispatcharrOutputProfile.self, from: Data(json.utf8))
+        #expect(profile.id == 3)
+        #expect(profile.name == "Apple TV")
+        #expect(profile.isActive)
+    }
+
+    @Test("Inactive profiles decode as inactive")
+    func decodesInactive() throws {
+        let json = #"{"id":7,"name":"Retired","is_active":false}"#
+        let profile = try JSONDecoder().decode(DispatcharrOutputProfile.self, from: Data(json.utf8))
+        #expect(!profile.isActive)
+    }
+
+    @Test("Missing name and is_active fall back sensibly")
+    func decodesSparsePayload() throws {
+        let profile = try JSONDecoder().decode(DispatcharrOutputProfile.self, from: Data(#"{"id":9}"#.utf8))
+        #expect(profile.name == "Profile #9")
+        #expect(profile.isActive)
+    }
+
+    @Test("List decodes from a plain array and from a paginated envelope")
+    func decodesListShapes() throws {
+        let array = #"[{"id":1,"name":"A","is_active":true},{"id":2,"name":"B","is_active":false}]"#
+        let plain = try JSONDecoder().decode(DispatcharrListResponse<DispatcharrOutputProfile>.self, from: Data(array.utf8))
+        #expect(plain.allItems.map(\.id) == [1, 2])
+
+        let envelope = #"{"count":1,"next":null,"results":[{"id":5,"name":"C","is_active":true}]}"#
+        let paged = try JSONDecoder().decode(DispatcharrListResponse<DispatcharrOutputProfile>.self, from: Data(envelope.utf8))
+        #expect(paged.allItems.map(\.id) == [5])
+        #expect(paged.count == 1)
+    }
+
+    // MARK: - URL construction
+
+    @Test("Original leaves both live URL forms untouched")
+    func originalOmitsParameter() throws {
+        let proxy = try #require(URL(string: "http://server:9191/proxy/ts/stream/abc-uuid"))
+        let xc = try #require(URL(string: "http://server:9191/live/user/p%40ss/42"))
+        #expect(DispatcharrOutputProfile.applying(profileId: nil, to: proxy) == proxy)
+        #expect(DispatcharrOutputProfile.applying(profileId: nil, to: xc) == xc)
+    }
+
+    @Test("A profile is appended to the proxy UUID form")
+    func appendsToProxyURL() throws {
+        let proxy = try #require(URL(string: "http://server:9191/proxy/ts/stream/abc-uuid"))
+        let url = DispatcharrOutputProfile.applying(profileId: 3, to: proxy)
+        #expect(url.absoluteString == "http://server:9191/proxy/ts/stream/abc-uuid?output_profile=3")
+    }
+
+    @Test("A profile is appended to the XC credential form, keeping the encoded password")
+    func appendsToXCURL() throws {
+        let xc = try #require(URL(string: "http://server:9191/live/user/p%40ss/42"))
+        let url = DispatcharrOutputProfile.applying(profileId: 3, to: xc)
+        #expect(url.absoluteString == "http://server:9191/live/user/p%40ss/42?output_profile=3")
+    }
+
+    @Test("Existing query items are preserved and a stale output_profile is replaced")
+    func preservesExistingQuery() throws {
+        let base = try #require(URL(string: "http://server/proxy/ts/stream/u?session_id=s1&output_profile=1"))
+        let url = DispatcharrOutputProfile.applying(profileId: 3, to: base)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+        #expect(items.first(where: { $0.name == "session_id" })?.value == "s1")
+        #expect(items.filter { $0.name == "output_profile" }.map(\.value) == ["3"])
+    }
+
+    // MARK: - Resolution / fallback
+
+    private let active = DispatcharrOutputProfile(id: 3, name: "Apple TV", isActive: true)
+    private let inactive = DispatcharrOutputProfile(id: 7, name: "Retired", isActive: false)
+
+    @Test("No selection resolves to Original with no notice")
+    func nilSelectionIsOriginal() {
+        let resolution = DispatcharrOutputProfile.resolve(selectedId: nil, available: [active])
+        #expect(resolution == .original)
+        #expect(resolution.profileId == nil)
+        #expect(resolution.notice == nil)
+    }
+
+    @Test("A selected active profile is sent")
+    func activeSelectionIsSent() {
+        let resolution = DispatcharrOutputProfile.resolve(selectedId: 3, available: [active, inactive])
+        #expect(resolution == .profile(active))
+        #expect(resolution.profileId == 3)
+        #expect(resolution.notice == nil)
+    }
+
+    @Test("A deleted or inactive profile falls back to Original with a visible notice")
+    func missingSelectionFallsBack() {
+        for selected in [7, 99] {
+            let resolution = DispatcharrOutputProfile.resolve(selectedId: selected, available: [active, inactive])
+            #expect(resolution.profileId == nil)
+            let notice = resolution.notice ?? ""
+            #expect(notice.contains("#\(selected)"))
+            #expect(notice.contains("original"))
+        }
+    }
+
+    @Test("An unreadable profile list falls back to Original and says so")
+    func unknownServerListFallsBack() {
+        let resolution = DispatcharrOutputProfile.resolve(selectedId: 3, available: nil)
+        #expect(resolution.profileId == nil)
+        #expect(resolution.notice?.contains("Couldn't read") == true)
+    }
+
+    // MARK: - Persistence
+
+    @Test("Preferences default to Original")
+    func defaultsToOriginal() {
+        #expect(UserPreferences().outputProfileId == nil)
+    }
+
+    @Test("Preferences written before the setting existed decode to Original")
+    func legacyPreferencesDecodeToOriginal() throws {
+        let json = #"{"keywords":[],"seekBackwardSeconds":10,"seekForwardSeconds":30}"#
+        let prefs = try JSONDecoder().decode(UserPreferences.self, from: Data(json.utf8))
+        #expect(prefs.outputProfileId == nil)
+    }
+
+    @Test("Selection survives an encode/decode round trip")
+    func roundTrips() throws {
+        var prefs = UserPreferences()
+        prefs.outputProfileId = 3
+        let data = try JSONEncoder().encode(prefs)
+        let decoded = try JSONDecoder().decode(UserPreferences.self, from: data)
+        #expect(decoded.outputProfileId == 3)
+    }
+
+    @Test("Original is encoded as an absent key, not null")
+    func originalEncodesAsAbsent() throws {
+        let data = try JSONEncoder().encode(UserPreferences())
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(object?["outputProfileId"] == nil)
+    }
+
+    // MARK: - NextPVR unaffected
+
+    @Test("The NextPVR stream quality setting is untouched by the output profile field")
+    func nextPVRQualityIndependent() throws {
+        var prefs = UserPreferences()
+        prefs.outputProfileId = 3
+        #expect(prefs.streamQuality == .original)
+        let decoded = try JSONDecoder().decode(UserPreferences.self, from: JSONEncoder().encode(prefs))
+        #expect(decoded.streamQuality == .original)
+        #expect(decoded.outputProfileId == 3)
+    }
+}

--- a/mock-server-dispatcharr/server.js
+++ b/mock-server-dispatcharr/server.js
@@ -66,6 +66,14 @@ const SHOW_NOUNS = [
 
 const DURATIONS = [15, 30, 30, 30, 60, 60, 60, 60, 90, 120, 120, 180];
 
+// Output profiles (#161): post-delivery FFmpeg steps a client may request
+// with `?output_profile=<id>` on a live stream URL.
+const OUTPUT_PROFILES = [
+  { id: 1, name: "Media Server (AC3 Audio)", command: "ffmpeg", parameters: "-c:v copy -c:a ac3", is_active: true, locked: true },
+  { id: 3, name: "Apple TV (fMP4 H.264/AAC)", command: "ffmpeg", parameters: "-c:v libx264 -c:a aac -movflags frag_keyframe+empty_moov", is_active: true, locked: false },
+  { id: 7, name: "Retired 480p", command: "ffmpeg", parameters: "-vf scale=-2:480", is_active: false, locked: false },
+];
+
 const CHANNEL_GROUPS = [
   { id: 1, name: "News" },
   { id: 2, name: "Sports" },
@@ -650,6 +658,12 @@ function handleRequest(req, res) {
     return json(res, CHANNEL_GROUPS);
   }
 
+  // Output profiles (#161) — mirrors `core/serializers.py` OutputProfileSerializer.
+  // The inactive one must never be offered or sent by the client.
+  if (path === "/api/core/outputprofiles/") {
+    return json(res, OUTPUT_PROFILES);
+  }
+
   // EPG programs — paginated list of all programs (used by DispatcherClient)
   if (path === "/api/epg/programs/") {
     const allPrograms = [...PROGRAMS, ...EDGE_CASES];
@@ -723,9 +737,18 @@ function handleRequest(req, res) {
     return;
   }
 
-  // Stream (mock)
+  // Stream (mock). Echoes the requested output profile (#161) so a URL built
+  // by the client can be checked against the server's active list.
   if (path.startsWith("/proxy/ts/stream/")) {
-    return json(res, { detail: "Mock server does not provide streams." }, 404);
+    const requestedProfile = url.searchParams.get("output_profile");
+    const profile = requestedProfile
+      ? OUTPUT_PROFILES.find((p) => String(p.id) === requestedProfile && p.is_active) || null
+      : null;
+    return json(
+      res,
+      { detail: "Mock server does not provide streams.", output_profile: profile ? profile.id : null },
+      404
+    );
   }
 
   // Switch the source an active channel is playing


### PR DESCRIPTION
Closes #161

## Summary

Dispatcharr applies a post-delivery FFmpeg/remux step for one client when a live URL carries `?output_profile=<id>`. This adds a **Dispatcharr-only** "Live TV Output Profile" setting backed by the server's active profile list.

- **Model** `DispatcharrOutputProfile` decodes `id` / `name` / `is_active` from `GET /api/core/outputprofiles/`, and holds the pure URL/resolution logic (append the query item while preserving existing ones; resolve a saved id to original / profile / unavailable-with-notice).
- **Preference** `UserPreferences.outputProfileId: Int?`. Nil is Original (default). Legacy blobs decode to nil; Original encodes as an absent key.
- **Client** `DispatcherClient.liveStreamURL` builds the pre-existing URL for both forms (`/proxy/ts/stream/{uuid}` and `/live/{user}/{pass}/{id}`), then applies the resolved profile. Active profiles are fetched and cached, re-fetched when the saved id is missing, and any fallback sets `streamQualityNotice` (shown by the existing player banner) and logs a network event.
- **Entry points** The deep-link handler in `AppEntry.swift` no longer prefers the raw `Channel.streamURL`; it goes through the client like every other live entry point.
- **Settings** Picker on iOS/macOS, row + popup on tvOS. Lists Original plus active profiles, keeps a visible "unavailable" row when the saved id is gone, and explains the fallback when the endpoint could not be read.
- **Mock server** `/api/core/outputprofiles/` with an inactive profile; the stream route echoes the requested profile.
- **Tests** `OutputProfileTests` covers decoding (plain array and paginated envelope), both URL forms, Original leaving URLs untouched, query preservation, fallback resolution, and persistence.

## Compatibility

- NextPVR: the preference field defaults to nil and all UI is behind `#if DISPATCHERPVR`; stream-quality tests unchanged and passing.
- Older Dispatcharr / restricted accounts: an unreadable profile list falls back to Original with a notice rather than failing auth or channel loading.
- `output_profile` is never sent when Original is selected.
- Recording, VOD and catch-up URLs untouched.

## Verification

| Check | Result |
|---|---|
| Dispatcharr iOS sim build | succeeded |
| NextPVR iOS sim build | succeeded |
| Dispatcharr tvOS sim build (incl. Top Shelf) | succeeded |
| OutputProfile + StreamQuality + UserPreferences suites, both schemes | 62 passed, 0 failed |

## Notes for review

- Upstream reads `output_profile` on the proxy stream view (`_resolve_output_profile`) and ignores inactive/unknown ids. I could not locate the XC `/live/` route handler to confirm it forwards the query string; if it does not, the parameter is harmlessly ignored.
- When the profile list cannot be fetched at all, we fall back to Original rather than sending the id blindly, per the issue's compatibility rule.

