### PR TITLE
Avoid auto-selecting audio description tracks

### DIFF
--- a/NexusPVR/Features/Player/MPVPlayerCore.swift
+++ b/NexusPVR/Features/Player/MPVPlayerCore.swift
@@ -639,6 +639,12 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
             var selected: Int32 = 0
             mpv_get_property(mpv, "track-list/\(i)/selected", MPV_FORMAT_FLAG, &selected)
 
+            var visualImpaired: Int32 = 0
+            mpv_get_property(mpv, "track-list/\(i)/visual-impaired", MPV_FORMAT_FLAG, &visualImpaired)
+
+            var hearingImpaired: Int32 = 0
+            mpv_get_property(mpv, "track-list/\(i)/hearing-impaired", MPV_FORMAT_FLAG, &hearingImpaired)
+
             tracks.append(MPVTrack(
                 id: Int(trackId),
                 type: trackType,
@@ -647,7 +653,9 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
                 codec: codec,
                 channels: channels,
                 bitrate: bitrate > 0 ? Int(bitrate) : nil,
-                isSelected: selected != 0
+                isSelected: selected != 0,
+                isVisualImpaired: visualImpaired != 0,
+                isHearingImpaired: hearingImpaired != 0
             ))
         }
         return tracks
@@ -664,6 +672,19 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
         DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self] in
             self?.isChangingTrack = false
         }
+    }
+
+    /// mpv's auto-selection ignores the visual/hearing-impaired flags, so a
+    /// DVB audio-description stream listed first in the PMT wins by track id.
+    /// Move to the regular mix when one exists (issue: Harry Potter commentary).
+    private func avoidAccessibilityAudioTrackIfNeeded() {
+        guard let mpv = mpv else { return }
+        let tracks = getTrackList()
+        guard let targetId = MPVTrack.regularAudioTrackToSelect(in: tracks) else { return }
+        let selected = tracks.first { $0.type == "audio" && $0.isSelected }
+        print("MPV: Auto-selected audio track \(selected?.id ?? -1) is an accessibility track, switching to \(targetId)")
+        var value = Int64(targetId)
+        mpv_set_property(mpv, "aid", MPV_FORMAT_INT64, &value)
     }
 
     func getSubtitleText() -> String? {
@@ -1262,6 +1283,7 @@ nonisolated class MPVPlayerCore: NSObject, @unchecked Sendable {
 
         case MPV_EVENT_FILE_LOADED:
             print("MPV: File loaded successfully")
+            avoidAccessibilityAudioTrackIfNeeded()
 
         case MPV_EVENT_PLAYBACK_RESTART:
             print("MPV: Playback started/restarted")

--- a/NexusPVR/Features/Player/MPVTrack.swift
+++ b/NexusPVR/Features/Player/MPVTrack.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MPVTrack: Identifiable, Equatable {
+nonisolated struct MPVTrack: Identifiable, Equatable {
     let id: Int
     let type: String       // "video", "audio", "sub"
     let title: String?
@@ -16,6 +16,16 @@ struct MPVTrack: Identifiable, Equatable {
     let channels: String?  // audio only
     let bitrate: Int?      // demux-bitrate
     let isSelected: Bool
+    /// Audio description track for visually impaired viewers (DVB audio_type 3,
+    /// ffmpeg AV_DISPOSITION_VISUAL_IMPAIRED). mpv exposes this flag but does
+    /// not consider it when auto-selecting, so the app has to.
+    var isVisualImpaired: Bool = false
+    /// Hearing-impaired audio (DVB audio_type 2, AV_DISPOSITION_HEARING_IMPAIRED).
+    var isHearingImpaired: Bool = false
+
+    /// True for accessibility tracks that should not be chosen automatically
+    /// when a regular track is available.
+    var isAccessibilityTrack: Bool { isVisualImpaired || isHearingImpaired }
 
     var displayName: String {
         var parts: [String] = []
@@ -28,7 +38,31 @@ struct MPVTrack: Identifiable, Equatable {
         if parts.isEmpty {
             parts.append("Track \(id)")
         }
+        if isVisualImpaired {
+            parts.append("Audio Description")
+        } else if isHearingImpaired {
+            parts.append("Hearing Impaired")
+        }
         return parts.joined(separator: " - ")
+    }
+
+    /// Returns the id of the audio track to switch to when mpv's automatic
+    /// selection landed on an accessibility track (audio description or
+    /// hearing-impaired mix) while a regular track exists, or nil when the
+    /// current selection should be left alone.
+    ///
+    /// mpv 0.41 ranks audio tracks by default flag, then lowest id, and never
+    /// looks at the impaired flags. DVB broadcasters often list the audio
+    /// description stream first, so this is needed to get the main mix.
+    static func regularAudioTrackToSelect(in tracks: [MPVTrack]) -> Int? {
+        let audio = tracks.filter { $0.type == "audio" }
+        guard let selected = audio.first(where: { $0.isSelected }),
+              selected.isAccessibilityTrack else { return nil }
+        let regular = audio.filter { !$0.isAccessibilityTrack }
+        // Prefer a regular track in the same language as the one mpv picked,
+        // otherwise the first regular track in stream order.
+        let sameLang = regular.first { $0.lang == selected.lang }
+        return (sameLang ?? regular.first)?.id
     }
 
     var audioDetail: String {

--- a/NexusPVRTests/MPVTrackTests.swift
+++ b/NexusPVRTests/MPVTrackTests.swift
@@ -1,0 +1,72 @@
+//
+//  MPVTrackTests.swift
+//  NexusPVRTests
+//
+//  Automatic avoidance of audio-description / hearing-impaired audio tracks.
+//
+
+import Testing
+@testable import NextPVR
+
+struct MPVTrackTests {
+
+    private func audio(_ id: Int, lang: String? = "eng", selected: Bool = false,
+                       visualImpaired: Bool = false, hearingImpaired: Bool = false) -> MPVTrack {
+        MPVTrack(id: id, type: "audio", title: nil, lang: lang, codec: "mp2", channels: "2",
+                 bitrate: nil, isSelected: selected,
+                 isVisualImpaired: visualImpaired, isHearingImpaired: hearingImpaired)
+    }
+
+    @Test func switchesFromAudioDescriptionToRegularTrack() {
+        let tracks = [
+            MPVTrack(id: 1, type: "video", title: nil, lang: nil, codec: "h264", channels: nil, bitrate: nil, isSelected: true),
+            audio(1, selected: true, visualImpaired: true),
+            audio(2),
+        ]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == 2)
+    }
+
+    @Test func switchesFromHearingImpairedTrack() {
+        let tracks = [audio(1, selected: true, hearingImpaired: true), audio(2)]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == 2)
+    }
+
+    @Test func leavesRegularSelectionAlone() {
+        let tracks = [audio(1, selected: true), audio(2, visualImpaired: true)]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == nil)
+    }
+
+    @Test func keepsAccessibilityTrackWhenNothingElseExists() {
+        let tracks = [audio(1, selected: true, visualImpaired: true), audio(2, hearingImpaired: true)]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == nil)
+    }
+
+    @Test func nothingSelectedDoesNothing() {
+        let tracks = [audio(1, visualImpaired: true), audio(2)]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == nil)
+    }
+
+    @Test func prefersRegularTrackInSameLanguage() {
+        let tracks = [
+            audio(1, lang: "eng", selected: true, visualImpaired: true),
+            audio(2, lang: "mri"),
+            audio(3, lang: "eng"),
+        ]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == 3)
+    }
+
+    @Test func fallsBackToFirstRegularTrackWhenNoLanguageMatch() {
+        let tracks = [
+            audio(1, lang: "eng", selected: true, visualImpaired: true),
+            audio(2, lang: "mri"),
+            audio(3, lang: "fra"),
+        ]
+        #expect(MPVTrack.regularAudioTrackToSelect(in: tracks) == 2)
+    }
+
+    @Test func displayNameLabelsAccessibilityTracks() {
+        #expect(audio(1, visualImpaired: true).displayName.hasSuffix("Audio Description"))
+        #expect(audio(1, hearingImpaired: true).displayName.hasSuffix("Hearing Impaired"))
+        #expect(!audio(1).displayName.contains("Audio Description"))
+    }
+}


### PR DESCRIPTION
## Problem

A user reported StreamClient playing the "commentary" track by default on a Freeview NZ recording of Harry Potter. The NextPVR server logs show the client streamed the raw `.ts` natively, so track selection is entirely mpv's. mpv 0.41's `compare_track()` ranks audio by default flag, then lowest track id, and never looks at the visual-impaired / hearing-impaired dispositions. When a broadcaster lists the audio-description stream first in the PMT, it wins.

## Fix

- `MPVTrack` gains `isVisualImpaired` / `isHearingImpaired` (from `track-list/N/visual-impaired` and `hearing-impaired`) and a pure `regularAudioTrackToSelect(in:)` helper.
- On `MPV_EVENT_FILE_LOADED`, if mpv's selection is an accessibility track and a regular one exists, switch to it (same language preferred, else first in stream order). Left alone when all tracks are flagged or nothing is selected.
- Audio picker labels such tracks "Audio Description" / "Hearing Impaired".

Only works when the broadcaster tags the stream with the DVB audio type descriptor (ffmpeg maps it to `AV_DISPOSITION_VISUAL_IMPAIRED`); untagged duplicate tracks remain indistinguishable, but are at least labeled.

## Testing

- New `MPVTrackTests` (8 tests) covering the switch, no-op cases, language preference, and labels — all pass on iOS simulator (NextPVR scheme).
